### PR TITLE
OTP Bug Fix

### DIFF
--- a/app/server/api/auth_api.py
+++ b/app/server/api/auth_api.py
@@ -933,6 +933,23 @@ class TwoFactorAuthAPI(MethodView):
         otp_token = request_data.get('otp')
         otp_expiry_interval = request_data.get('otp_expiry_interval')
 
+        malformed_otp = False
+        try:
+            int(otp_token)
+        except ValueError:
+            malformed_otp = True
+
+        if not isinstance(otp_token, str) or len(otp_token) != 6:
+            malformed_otp = True
+
+        if malformed_otp:
+            response_object = {
+                'status': "Failed",
+                'message': "OTP must be a 6 digit numeric string"
+            }
+
+            return make_response(jsonify(response_object)), 400
+
         if user.validate_OTP(otp_token):
             tfa_auth_token = user.encode_TFA_token(otp_expiry_interval)
             user.TFA_enabled = True

--- a/app/server/models/user.py
+++ b/app/server/models/user.py
@@ -480,15 +480,10 @@ class User(ManyOrgBase, ModelBase):
         return decrypt_string(self._TFA_secret)
 
     def validate_OTP(self, input_otp):
-        try:
-            p = int(input_otp)
-        except ValueError:
-            return False
-        else:
-            secret = self.get_TFA_secret()
-            server_otp = pyotp.TOTP(secret)
-            ret = server_otp.verify(p, valid_window=2)
-            return ret
+        secret = self.get_TFA_secret()
+        server_otp = pyotp.TOTP(secret)
+        ret = server_otp.verify(input_otp, valid_window=2)
+        return ret
 
     def set_one_time_code(self, supplied_one_time_code):
         if supplied_one_time_code is None:


### PR DESCRIPTION
Fixing that annoying bug where the otp test failed some time. What was happing was the otp was being forced into an int (don't ask why), so otps such as '012345' were being converted into '12345' which was causing the test to fail 1 in 10 times.
