### PR TITLE
Transfer Account List Performance Fixes

### DIFF
--- a/app/client/components/pages/transferAccountListPage.jsx
+++ b/app/client/components/pages/transferAccountListPage.jsx
@@ -47,8 +47,13 @@ class TransferAccountListPage extends React.Component {
           query = {account_type: 'beneficiary'};
 
       } else {
-          query = null;
+          query = {};
       }
+      
+      if (this.props.transferAccounts.loadStatus.lastQueried) {
+        query.updated_after = this.props.transferAccounts.loadStatus.lastQueried;
+      }
+
 
       const path = null;
 

--- a/app/client/components/pages/transferAccountListPage.jsx
+++ b/app/client/components/pages/transferAccountListPage.jsx
@@ -49,7 +49,7 @@ class TransferAccountListPage extends React.Component {
       } else {
           query = {};
       }
-      
+
       if (this.props.transferAccounts.loadStatus.lastQueried) {
         query.updated_after = this.props.transferAccounts.loadStatus.lastQueried;
       }

--- a/app/client/components/transferAccount/singleTransferAccountWrapper.jsx
+++ b/app/client/components/transferAccount/singleTransferAccountWrapper.jsx
@@ -25,7 +25,6 @@ class SingleTransferAccountWrapper extends React.Component {
 
     if (transferAccount.credit_receives || transferAccount.credit_sends) {
       var creditTransferIds = transferAccount.credit_receives.concat(transferAccount.credit_sends);
-      console.log(creditTransferIds);
     }
 
     return (

--- a/app/client/components/transferAccount/transferAccountList.jsx
+++ b/app/client/components/transferAccount/transferAccountList.jsx
@@ -172,10 +172,6 @@ class TransferAccountList extends React.Component {
 
 
   render() {
-    console.log('TA Dict', this.state.idSelectedStatus);
-
-    console.log('TA IDS', this.get_selected_ids_array(this.state.idSelectedStatus));
-
     const {account_type} = this.state;
     const loadingStatus = this.props.transferAccounts.loadStatus.isRequesting;
     let accountTypes = Object.keys(TransferAccountTypes);

--- a/app/client/reducers/transferAccountReducer.js
+++ b/app/client/reducers/transferAccountReducer.js
@@ -45,7 +45,8 @@ const byId = (state = {}, action) => {
 const initialLoadStatusState = {
   isRequesting: false,
   error: null,
-  success: false
+  success: false,
+  lastQueried: null
 };
 
 const loadStatus = (state = initialLoadStatusState, action) => {
@@ -54,7 +55,7 @@ const loadStatus = (state = initialLoadStatusState, action) => {
       return {...state, isRequesting: true};
 
     case LOAD_TRANSFER_ACCOUNTS_SUCCESS:
-      return {...state, isRequesting: false, success: true};
+      return {...state, isRequesting: false, success: true, lastQueried: action.lastQueried || state.lastQueried};
 
     case LOAD_TRANSFER_ACCOUNTS_FAILURE:
       return {...state, isRequesting: false, error: action.error};

--- a/app/client/sagas/transferAccountSagas.js
+++ b/app/client/sagas/transferAccountSagas.js
@@ -58,7 +58,7 @@ function* loadTransferAccounts({payload}) {
 
     yield call(updateStateFromTransferAccount, load_result.data);
 
-    yield put({type: LOAD_TRANSFER_ACCOUNTS_SUCCESS})
+    yield put({type: LOAD_TRANSFER_ACCOUNTS_SUCCESS, lastQueried: load_result.query_time})
 
   } catch (fetch_error) {
 

--- a/app/server/api/transfer_account_api.py
+++ b/app/server/api/transfer_account_api.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, make_response, jsonify, g, Response
 from flask.views import MethodView
-
+import datetime
 import orjson
 
 from sqlalchemy.orm import lazyload
@@ -75,6 +75,7 @@ class TransferAccountAPI(MethodView):
                 'message': 'Successfully Loaded.',
                 'items': total_items,
                 'pages': total_pages,
+                'query_time': datetime.datetime.utcnow(),
                 'data': {'transfer_accounts': result.data}
             }
 

--- a/app/server/models/utils.py
+++ b/app/server/models/utils.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
-
 from flask import g, request
 import datetime
+from dateutil import parser
 
 from sqlalchemy import event, inspect
 from sqlalchemy.ext.declarative import declared_attr
@@ -53,8 +53,13 @@ def paginate_query(query, queried_object=None, order_override=None):
     :returns: tuple of (item list, total number of items, total number of pages)
     """
 
+    updated_after = request.args.get('updated_after')
     page = request.args.get('page')
     per_page = request.args.get('per_page')
+
+    if updated_after:
+        parsed_time = parser.isoparse(updated_after)
+        query = query.filter(queried_object.updated > parsed_time)
 
     if order_override:
         query = query.order_by(order_override)


### PR DESCRIPTION
The current Transfer Account List page takes WAAAAAYYYY too long to load (up to a minute when there's 1000s of accounts). Long term fix is server side search etc.
Short term fix :
- Speeding up subsequent load times after the initial by only loading modified accounts 
- Technical improvements to the react rendering process namely:
-      reducing number of re-renderings
-     don't include ALL element a dict used for working out which rows were selected, but rather just assume non-present elements are not selected.