### PR TITLE
More comprehensive setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ app/server/static/javascript/bundle.*
 ngrok
 .ideabackup
 /whatsApp/chromedriver
-/ganacheDB/*
+/ganacheDB/
 Dockerrun.aws.json
 
 /venv/*

--- a/README.md
+++ b/README.md
@@ -33,9 +33,18 @@ cd app
 npm install
 ```
 
-### Enable the Simulator (Optional)
+### Setup Script
 
-If you wish to forego installing ganache and redis, you can enable a simulator mode. What this does is bypass the eth*worker and any queued jobs, and instead returns dummy responses to any functions relying on eth_worker. Be warned, this \_will* make your database fall out of sync with any ganache instance you have set up so use this with care, but it is very useful in eliminating dependencies when working on any features in the API or frontend. It also allows you to run `quick_setup_script.py` without additional dependencies.  
+For quick setup, run `quick_setup_script.sh` with `MASTER_WALLET_PK` set as an environment variable to the master private key found in `/config_files/secret/local_secrets.ini/`.
+
+```
+quick_setup_script.sh [activation path for your python env]
+```
+
+#### Enable the Simulator (Optional)
+
+If you wish to forego installing ganache and redis, you can enable a simulator mode. What this does is bypass the eth_worker and any queued jobs, and instead returns dummy responses to any functions relying on eth_worker. _Be warned, this will make your database fall out of sync with any ganache instance you have set up so use this with care_, but it is very useful in eliminating dependencies when working on any features in the API or frontend. It also allows you to run `contract_setup_script.py` without additional dependencies.
+
 To enable simulator mode, open `/config_files/local_config.ini` and add the line `enable_simulator_mode = true` under the `[APP]` heading.
 
 ### Run the web app in a Virtual Env

--- a/app/migrations/seed.py
+++ b/app/migrations/seed.py
@@ -2,7 +2,6 @@ import sys
 import os
 from sqlalchemy import func
 
-
 sys.path.append(os.path.abspath(os.path.join(os.getcwd(), "..", "..")))
 sys.path.append(os.path.abspath(os.path.join(os.getcwd(), "..")))
 

--- a/config_files/public/local_config.ini
+++ b/config_files/public/local_config.ini
@@ -18,7 +18,7 @@ tfa_required_roles                           = superadmin,admin
 mobile_version                               = 1.0.1
 web_version                                  = 1
 enable_simulator_mode                        = false
-sempoadmin_emails                            = example@example.com,example2@example2.com
+sempoadmin_emails                            = admin@acme.org,example@example.com
 
 [DATABASE]
 host         = localhost

--- a/contract_setup_script.py
+++ b/contract_setup_script.py
@@ -278,52 +278,34 @@ def _base_setup(s, reserve_token_id):
     # exchange_contract_id = 1
 
     org_id = s.create_cic_organisation(
-        organisation_name='Grassroots Economics',
+        organisation_name='ACME Org',
         custom_welcome_message_key='grassroots',
-        timezone='Africa/Nairobi',
+        timezone='Australia/Melbourne',
         country_code='AU',
         exchange_contract_id=exchange_contract_id,
-        name='Sarafu',
-        symbol='SARAFU',
+        name='ACME',
+        symbol='ACME',
         issue_amount_wei=int(10000000e18),
         reserve_deposit_wei=int(10000e18),
         reserve_ratio_ppm=250000
     )
+
     bind_1 = s.bind_me_to_organisation_as_admin(org_id)
-
-    tt = 4
-
-    # foobar_org_id = s.create_cic_organisation(
-    #     organisation_name='Foo Org',
-    #     exchange_contract_id=exchange_contract_id,
-    #     custom_welcome_me ssage_key=None,
-    #     timezone='Africa/Nairobi',
-    #     name='FooBar',
-    #     symbol='FOO',
-    #     issue_amount_wei=int(100000e18),
-    #     reserve_deposit_wei=int(10e18),
-    #     reserve_ratio_ppm=250000
-    # )
-    # bind_2 = s.bind_me_to_organisation_as_admin(foobar_org_id)
-
 
 def local_setup():
     s = Setup(
         api_host='http://0.0.0.0:9000/api/v1/',
-        email=os.environ.get('LOCAL_EMAIL'),
-        password=os.environ.get('LOCAL_PASSWORD')
+        email=os.environ.get('LOCAL_EMAIL', 'admin@acme.org'),
+        password=os.environ.get('LOCAL_PASSWORD', 'C0rrectH0rse')
     )
 
     reserve_token_id = s.create_reserve_token(
-        name='Kenyan Shilling',
-        symbol='Ksh',
+        name='Reserve Currency',
+        symbol='RCU',
         fund_amount_wei=int(10000e18)
     )
 
     _base_setup(s, reserve_token_id)
-
-    tt = 4
-
 
 if __name__ == '__main__':
 

--- a/ganache_cli.sh
+++ b/ganache_cli.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-ganache-cli -l 80000000 -i 42 --db './ganacheDB' \
---account="0x00f49bc12b2e102e072ee086482e700ad7fe2b5ee417697b13ca04e4dc1572d9,10000000000000000000000000"
+ganache-cli -l 80000000 -i 42 \
+--account="0x00f49bc12b2e102e072ee086482e700ad7fe2b5ee417697b13ca04e4dc1572d9,10000000000000000000000000" \
+--db './ganacheDB'

--- a/ganache_cli.sh
+++ b/ganache_cli.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
+set +e
+
+mkdir ./ganacheDB
 
 ganache-cli -l 80000000 -i 42 \
---account="0x00f49bc12b2e102e072ee086482e700ad7fe2b5ee417697b13ca04e4dc1572d9,10000000000000000000000000" \
+--account="${MASTER_WALLET_PK},10000000000000000000000000" \
 --db './ganacheDB'

--- a/quick_setup_script.sh
+++ b/quick_setup_script.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -m
+
+source $1
+
+echo "This will wipe ALL local Sempo data. Continue? (y/N)"
+read continueInput
+
+if [ $continueInput != y ]
+then
+echo aborting
+exit 0
+fi
+
+set +e
+
+echo ~~~~Resetting readis
+redis-server
+redis-cli FLUSHALL
+
+echo ~~~~Resetting postgres
+db_server=postgres://${DB_USER:-postgres}:${DB_PASSWORD:-password}@localhost:5432
+app_db=$db_server/${APP_DB:-sempo_blockchain_local}
+eth_worker_db=$db_server/${APP_DB:-eth_worker}
+
+psql $app_db -c 'DROP SCHEMA public CASCADE'
+psql $app_db -c 'CREATE SCHEMA public'
+
+psql $eth_worker_db -c 'DROP SCHEMA public CASCADE'
+psql $eth_worker_db -c 'CREATE SCHEMA public'
+
+
+cd app
+python manage.py db upgrade
+
+cd ../eth_worker/
+alembic upgrade heads
+
+echo ~~~~Resetting Ganache
+kill $(ps aux | grep '[g]anache-cli' | awk '{print $2}')
+
+ganache-cli -l 80000000 -i 42 --account="${MASTER_WALLET_PK},10000000000000000000000000" &
+sleep 5
+
+set -e
+
+echo ~~~Starting worker
+celery -A eth_manager worker --loglevel=INFO --concurrency=8 --pool=eventlet -Q processor,celery &
+sleep 5
+
+echo ~~~Seeding Data
+cd ../app/migrations/
+python -u seed.py
+
+echo ~~~Starting App
+
+cd ../
+python run.py &
+sleep 5
+
+echo ~~~Creating Default Account
+curl 'http://0.0.0.0:9000/api/v1/auth/register/' -H 'Connection: keep-alive' -H 'Accept: application/json' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36' -H 'Content-Type: application/json' -H 'Origin: http://0.0.0.0:9000' -H 'Referer: http://0.0.0.0:9000/login/sign-up' -H 'Accept-Language: en-US,en;q=0.9' -H 'Cookie: _ga=GA1.1.889304486.1568334223; _hp2_id.2461187681=%7B%22userId%22%3A%221109895996535790%22%2C%22pageviewId%22%3A%224425033411764656%22%2C%22sessionId%22%3A%221479247222978424%22%2C%22identity%22%3Anull%2C%22trackerVersion%22%3A%224.0%22%7D' --data-binary '{"username":"admin@acme.org","password":"C0rrectH0rse","referral_code":null}' --compressed --insecure
+psql $app_db -c 'UPDATE public."user" SET is_activated=TRUE'
+
+echo ~~~Setting up Contracts
+cd ../
+python contract_setup_script.py
+
+echo ~~~Killing Python Processes
+set +e
+kill $(ps aux | grep '[r]un.py' | awk '{print $2}')
+kill $(ps aux | grep '[c]elery' | awk '{print $2}')
+
+echo ~~~Bringing Ganache to foreground
+fg 1
+

--- a/quick_setup_script.sh
+++ b/quick_setup_script.sh
@@ -12,6 +12,14 @@ echo aborting
 exit 0
 fi
 
+if [ -z ${MASTER_WALLET_PK+x} ]
+then
+echo "\$MASTER_WALLET_PK is empty"
+exit 0
+else
+echo "\$MASTER_WALLET_PK is NOT empty"
+fi
+
 set +e
 
 echo ~~~~Resetting readis

--- a/quick_setup_script.sh
+++ b/quick_setup_script.sh
@@ -3,14 +3,9 @@ set -m
 
 source $1
 
-echo "This will wipe ALL local Sempo data. Continue? (y/N)"
-read continueInput
-
-if [ $continueInput != y ]
-then
-echo aborting
-exit 0
-fi
+echo "This will wipe ALL local Sempo data."
+echo "Persist Ganache? (y/N)"
+read ganachePersistInput
 
 if [ -z ${MASTER_WALLET_PK+x} ]
 then
@@ -23,7 +18,7 @@ fi
 set +e
 
 echo ~~~~Resetting readis
-redis-server
+redis-server &
 redis-cli FLUSHALL
 
 echo ~~~~Resetting postgres
@@ -45,9 +40,18 @@ cd ../eth_worker/
 alembic upgrade heads
 
 echo ~~~~Resetting Ganache
+cd ../
 kill $(ps aux | grep '[g]anache-cli' | awk '{print $2}')
+rm -R ./ganacheDB
 
-ganache-cli -l 80000000 -i 42 --account="${MASTER_WALLET_PK},10000000000000000000000000" &
+if [ $ganachePersistInput != y ]
+then
+  ganache-cli -l 80000000 -i 42 --account="${MASTER_WALLET_PK},10000000000000000000000000" &
+else
+  mkdir ganacheDB
+  ganache-cli -l 80000000 -i 42 --account="${MASTER_WALLET_PK},10000000000000000000000000" --db './ganacheDB' &
+fi
+
 sleep 5
 
 set -e
@@ -57,7 +61,7 @@ celery -A eth_manager worker --loglevel=INFO --concurrency=8 --pool=eventlet -Q 
 sleep 5
 
 echo ~~~Seeding Data
-cd ../app/migrations/
+cd ./app/migrations/
 python -u seed.py
 
 echo ~~~Starting App

--- a/quick_setup_script.sh
+++ b/quick_setup_script.sh
@@ -57,11 +57,12 @@ sleep 5
 set -e
 
 echo ~~~Starting worker
+cd eth_worker
 celery -A eth_manager worker --loglevel=INFO --concurrency=8 --pool=eventlet -Q processor,celery &
 sleep 5
 
 echo ~~~Seeding Data
-cd ./app/migrations/
+cd ../app/migrations/
 python -u seed.py
 
 echo ~~~Starting App


### PR DESCRIPTION
Fixes the issue with the python setup script and creates new more comprehensive bash one:
`quick_setup_script.sh`

To use:
- set env variable `MASTER_WALLET_PK` to the master private key found in your local ini secrets file 

-run `quick_setup_script.sh [activation path for your python env] `

- once that's finished run, start app and worker as normal. Ganache will already be running