### PR TITLE
Improve location handling

### DIFF
--- a/app/migrations/versions/241af81119c4_extended_location_information.py
+++ b/app/migrations/versions/241af81119c4_extended_location_information.py
@@ -1,0 +1,66 @@
+"""extended location information
+
+Revision ID: 241af81119c4
+Revises: 6d8a938930ff
+Create Date: 2020-04-23 11:37:45.838998
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '241af81119c4'
+down_revision = '6d8a938930ff'
+branch_labels = None
+depends_on = None
+
+
+location_external_source_options = ('OSM', 'GEONAMES')
+location_external_source_enum = sa.Enum(*location_external_source_options, name='location_external_source_enum')
+
+ 
+def upgrade():
+
+    # hierarchically nested location resources
+    op.create_table('location',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('parent_id', sa.Integer()),
+            sa.Column('common_name', sa.String(), nullable=False),
+            sa.Column('latitude', sa.Numeric(), nullable=False),
+            sa.Column('longitude', sa.Numeric(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+    )
+   
+
+    # links to external entities describing the same location resource
+    op.create_table('location_external',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('location_id', sa.Integer(), nullable=False),
+            sa.Column('source', location_external_source_enum, nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['location_id'], ['location.id'])
+    )
+    c = op.get_bind()
+    c.execute("""ALTER TABLE location_external ADD COLUMN external_reference JSONB""")
+    op.create_index('external_id_source_idx', 'location_external', ['source', 'external_reference'], schema=None, unique=True)
+
+    # bind user to location, also preparing for improved modularization
+    # and clean-up of user-related objects in db
+    op.create_table('user_extension_association_table',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=False),
+            sa.Column('location_id', sa.Integer()),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['location_id'], ['location.id']),
+    )
+    op.create_index('user_extension_location_idx', 'user_extension_association_table', ['user_id', 'location_id'], schema=None, unique=True)
+
+
+def downgrade():
+    op.drop_index('user_extension_location_idx')
+    op.drop_table('user_extension_association_table')
+    op.drop_index('external_id_source_idx')
+    op.drop_table('location_external')
+    location_external_source_enum.drop(op.get_bind(), checkfirst=False)
+    op.drop_table('location')

--- a/app/server/models/location.py
+++ b/app/server/models/location.py
@@ -1,0 +1,43 @@
+from sqlalchemy.dialects.postgresql import JSON, JSONB
+
+from server import db
+from server.models import User
+from server.models.utils import ModelBase
+
+from share.location import LocationExternalSourceEnum
+
+class LocationExternal(ModelBase):
+    """Maps external map resources to location
+    """
+    
+    __tablename__ = 'location_external'
+
+    location_id = db.Column(db.Integer, db.ForeignKey('location.id'))
+    source = db.Column(db.Enum(LocationExternalSourceEnum))
+    external_reference = db.Column(JSONB)
+
+
+class Location(ModelBase):
+    """User extension table describing the user's location
+    """
+
+    __tablename__ = 'location'
+
+    id = db.Column(db.Integer, primary_key=True)
+    common_name = db.Column(db.String())
+    latitude = db.Column(db.Numeric)
+    longitude = db.Column(db.Numeric)
+    parent_id = db.Column(db.Integer, db.ForeignKey('location.id'))
+    parent = db.relationship('Location', remote_side=[id])
+
+    external_sources = db.relationship('LocationExternal',
+            primaryjoin='LocationExternal.location_id == Location.id',
+            lazy=True)
+
+    def __init__(self, common_name, latitude, longitude, parent=None, **kwargs):
+        super(Location, self).__init__(**kwargs)
+        self.common_name = common_name
+        self.latitude = latitude
+        self.longitude = longitude
+        if parent != None:
+            self.parent = parent

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -159,6 +159,17 @@ def new_credit_transfer(create_transfer_account_user, external_reserve_token):
     return credit_transfer
 
 @pytest.fixture(scope='function')
+def new_locations():
+    from server.models.location import Location
+
+    locations = {}
+    locations['top'] = Location('Croatia', 45.81318, 15.97624)
+    locations['node'] = Location('Porec', 45.22738, 13.59569, locations['top'])
+    locations['leaf'] = Location('Nice beach', 45.240173511, 13.597673455, locations['node'])
+
+    return locations
+
+@pytest.fixture(scope='function')
 def other_new_credit_transfer(create_transfer_account_user, external_reserve_token):
     # Janky copy paste job because of how pytest works
     from server.models.credit_transfer import CreditTransfer

--- a/test/unit/app/models/test_location.py
+++ b/test/unit/app/models/test_location.py
@@ -1,0 +1,9 @@
+import pytest
+
+import logging
+
+logg = logging.getLogger()
+
+def test_load_location(new_locations):
+    logg.error(new_locations)
+    pass


### PR DESCRIPTION
This PR follows from work migrating location strings in `public.user._location` to actual coordinates. It enables hierarchical relations of locations, aswell as preserving references to external objects (like osm).

A `user_extension_association_table` has been added for this relation, which also could link other user information later on that we would want to extract from the user table in a future cleanup.