### PR TITLE
Adding UWSGI Stats Server

### DIFF
--- a/app/_docker_app_script.sh
+++ b/app/_docker_app_script.sh
@@ -26,6 +26,6 @@ if [ "$CONTAINER_MODE" = 'TEST' ]; then
    fi
    bash <(curl -s https://codecov.io/bash) -cF python
 else
-  uwsgi --socket 0.0.0.0:9000 --protocol http  --processes 4 --enable-threads --module=server.wsgi:app
+  uwsgi --socket 0.0.0.0:9000 --protocol http  --processes 4 --enable-threads --module=server.wsgi:app --stats :3031 --stats-http
 fi
 

--- a/awsDockerrunTemplate.json
+++ b/awsDockerrunTemplate.json
@@ -21,6 +21,12 @@
           "name": "PYTHONUNBUFFERED",
           "value": 0
         }
+      ],
+      "portMappings": [
+        {
+          "hostPort": 3031,
+          "containerPort": 3031
+        }
       ]
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     depends_on:
       - postgres
       - eth_worker
+    ports:
+      - "3031:3031"
 
   eth_worker:
     build:


### PR DESCRIPTION
uWSGI docs recommend using the [stats server/uwsgitop ](https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html) to monitor apps and understand performance issues. See also https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html

This PR adds this.