### PR TITLE
Remove Transfer Account Load From Dashboard

### DIFF
--- a/app/client/components/pages/dashboardPage.jsx
+++ b/app/client/components/pages/dashboardPage.jsx
@@ -73,7 +73,6 @@ class DashboardPage extends React.Component {
       per_page: per_page,
       page: page
     });
-    this.buildFilterForAPI();
 
     const parsed = parseQuery(location.search);
 

--- a/app/client/components/pages/dashboardPage.jsx
+++ b/app/client/components/pages/dashboardPage.jsx
@@ -6,7 +6,6 @@ import { subscribe, unsubscribe } from "pusher-redux";
 import { PUSHER_CREDIT_TRANSFER } from "../../reducers/creditTransferReducer";
 import { LoginAction } from "../../reducers/auth/actions";
 import { loadCreditTransferList } from "../../reducers/creditTransferReducer";
-import { loadTransferAccounts } from "../../reducers/transferAccountReducer";
 import { loadCreditTransferFilters } from "../../reducers/creditTransferFilterReducer";
 
 import {
@@ -33,7 +32,6 @@ const HeatMap = lazy(() => import("../heatmap/heatmap.jsx"));
 const mapStateToProps = state => {
   return {
     creditTransfers: state.creditTransfers,
-    transferAccounts: state.transferAccounts,
     login: state.login
   };
 };
@@ -41,8 +39,6 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     logout: () => dispatch(LoginAction.logout()),
-    loadTransferAccountList: (query, path) =>
-      dispatch(loadTransferAccounts({ query, path })),
     loadCreditTransferList: (query, path) =>
       dispatch(loadCreditTransferList({ query, path })),
     loadCreditTransferFilters: (query, path) =>
@@ -89,17 +85,6 @@ class DashboardPage extends React.Component {
     this.props.loadCreditTransferFilters();
   }
 
-  buildFilterForAPI() {
-    let query = {};
-
-    if (this.props.transferAccounts.loadStatus.lastQueried) {
-      query.updated_after = this.props.transferAccounts.loadStatus.lastQueried;
-    }
-
-    const path = null;
-    this.props.loadTransferAccountList(query, path);
-  }
-
   componentWillUnmount() {
     this.unsubscribe();
   }
@@ -132,10 +117,7 @@ class DashboardPage extends React.Component {
   }
 
   render() {
-    if (
-      this.props.creditTransfers.loadStatus.isRequesting === true ||
-      this.props.transferAccounts.loadStatus.isRequesting === true
-    ) {
+    if (this.props.creditTransfers.loadStatus.isRequesting === true) {
       return (
         <WrapperDiv>
           <CenterLoadingSideBarActive>
@@ -156,10 +138,7 @@ class DashboardPage extends React.Component {
           </PageWrapper>
         </WrapperDiv>
       );
-    } else if (
-      this.props.creditTransfers.loadStatus.success === true &&
-      this.props.transferAccounts.loadStatus.success === true
-    ) {
+    } else if (this.props.creditTransfers.loadStatus.success === true) {
       return (
         <WrapperDiv>
           <PageWrapper>

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ logg = logging.getLogger(__name__)
 
 from web3 import Web3
 
-VERSION = '1.1.27'  # Remember to bump this in every PR
+VERSION = '1.1.28'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**

Currently when you load the dashboard, the system tries to load all transfer accounts, which slows the system down real bad. This load doesn't actually seem to do anything, so this PR removes it.

**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [X] QA your pull request. This includes running the app, login, testing changes etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
