### PR TITLE
Third-Party Sentry Support + Opt-Out

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ logg = logging.getLogger(__name__)
 
 from web3 import Web3
 
-VERSION = '1.1.33'  # Remember to bump this in every PR
+VERSION = '1.1.34'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
## Purpose  
The goal of this is to allow users to opt-out of our Sentry tracking, and also add the option to allow users to determine their own DSNs for Sentry tracking.   
  
## Proposed Approach   
- Keep Sempo DSNs in the repository, and keep them set in the config ini file  
- Add an organization-level setting in the database for React DSN, Server DSN, and Android App DSN. Also add a boolean indicating whether you want to use our DSN, or a third party one. We could also consider allowing users to do their own tracking in addition to reporting errors to us using [multiple DSNs](https://stackoverflow.com/questions/58718196/how-to-have-multiple-global-dsn-in-sentry-sdk-in-python). I think this would likely be a separate PR out of scope though.  
- Add an endpoint to serve the DSN for the FE and Android App. Also to set them (given sufficient permissions)  
    - The endpoint would basically be `if organization.third_party_enabled -> return organization.react_dsn, else -> return config.react_dsn`  
- When the server is started, in the __init__ file the app will decide (with the same logic the endpoint uses), whether to use the DSN from the settings file, or from the database. If the setting is changed, then `sentry_sdk.init` is re-run as a part of that change. 
- On the FE or the Android app, if a page is loaded and the DSN doesn't exist in local storage or cookies, try to hit the app's telemetry endpoint. There could also be some logic for clients to re-check the validity on every login (or maybe expire/refetch after n hours. I think every login is fine since this setting will _rarely_ change in most cases) 
  
## Potential Problems  
- Errors before Sentry is initialized on the frontend or app. I think the biggest risk here is on first-run, since there will be a DSN in storage as-usual on subsequent page loads  
- Keeping the DSN of our various forks and deployments up to date. The DSN is [not secret](https://forum.sentry.io/t/dsn-private-public/6297), but there are circumstances where you'd want to cycle them for new ones. In the future, we might have to set up a static page (Something like `https://withsempo.com/telemetry` perhaps), which is just a text file with Sempo DSNs which other clients can load on-the-fly instead of counting on them being in our repo.