### PR TITLE
convert CreditTransfer reducer to typescript and add a couple tests

### DIFF
--- a/app/client/__fixtures__/creditTransfer/creditTransferData.ts
+++ b/app/client/__fixtures__/creditTransfer/creditTransferData.ts
@@ -2,10 +2,14 @@ import { CreditTransfer } from "../../reducers/creditTransfer/types";
 
 export const CreditTransferData: CreditTransfer = {
   transfer_subtype: "DISBURSEMENT", // or RECLAMATON
-  transfer_type: "DISBURSEMENT" // or RECLAMATON
+  transfer_type: "DISBURSEMENT", // or RECLAMATON,
+  transfer_amount: 10,
+  transfer_status: "PENDING"
 };
 
 export const AnotherCreditTransferData: CreditTransfer = {
   transfer_subtype: "RECLAMATON",
-  transfer_type: "RECLAMATION"
+  transfer_type: "RECLAMATION",
+  transfer_amount: 10,
+  transfer_status: "COMPLETE"
 };

--- a/app/client/__fixtures__/creditTransfer/creditTransferData.ts
+++ b/app/client/__fixtures__/creditTransfer/creditTransferData.ts
@@ -1,0 +1,11 @@
+import { CreditTransfer } from "../../reducers/creditTransfer/types";
+
+export const CreditTransferData: CreditTransfer = {
+  transfer_subtype: "DISBURSEMENT", // or RECLAMATON
+  transfer_type: "DISBURSEMENT" // or RECLAMATON
+};
+
+export const AnotherCreditTransferData: CreditTransfer = {
+  transfer_subtype: "RECLAMATON",
+  transfer_type: "RECLAMATION"
+};

--- a/app/client/__tests__/functional/reducers/creditTransfer/reducers.test.ts
+++ b/app/client/__tests__/functional/reducers/creditTransfer/reducers.test.ts
@@ -1,0 +1,36 @@
+import "../../../setup/setupTests.js";
+import { CreditTransfers } from "../../../../reducers/creditTransfer/types";
+import { updateCreditTransferListRequest } from "../../../../reducers/creditTransfer/actions";
+import { byId } from "../../../../reducers/creditTransfer/reducers";
+import {
+  CreditTransferData,
+  AnotherCreditTransferData
+} from "../../../../__fixtures__/creditTransfer/creditTransferData";
+
+describe("byId reducer", () => {
+  let updatedState: CreditTransfers;
+
+  beforeEach(() => {
+    updatedState = byId(
+      {},
+      updateCreditTransferListRequest({ "0x1234": CreditTransferData })
+    );
+  });
+
+  it("add single creditTransfer", () => {
+    expect(Object.keys(updatedState)).toHaveLength(1);
+    expect(updatedState["0x1234"]).toEqual(CreditTransferData);
+  });
+
+  it("add multiple creditTransfers", () => {
+    updatedState = byId(
+      {},
+      updateCreditTransferListRequest({
+        "0x1234": CreditTransferData,
+        "0x2345": AnotherCreditTransferData
+      })
+    );
+    expect(Object.keys(updatedState)).toHaveLength(2);
+    expect(updatedState["0x2345"]).toEqual(AnotherCreditTransferData);
+  });
+});

--- a/app/client/__tests__/functional/reducers/creditTransfer/reducers.test.ts
+++ b/app/client/__tests__/functional/reducers/creditTransfer/reducers.test.ts
@@ -1,6 +1,6 @@
 import "../../../setup/setupTests.js";
 import { CreditTransfers } from "../../../../reducers/creditTransfer/types";
-import { updateCreditTransferListRequest } from "../../../../reducers/creditTransfer/actions";
+import { CreditTransferAction } from "../../../../reducers/creditTransfer/actions";
 import { byId } from "../../../../reducers/creditTransfer/reducers";
 import {
   CreditTransferData,
@@ -13,7 +13,9 @@ describe("byId reducer", () => {
   beforeEach(() => {
     updatedState = byId(
       {},
-      updateCreditTransferListRequest({ "0x1234": CreditTransferData })
+      CreditTransferAction.updateCreditTransferListRequest({
+        "0x1234": CreditTransferData
+      })
     );
   });
 
@@ -25,7 +27,7 @@ describe("byId reducer", () => {
   it("add multiple creditTransfers", () => {
     updatedState = byId(
       {},
-      updateCreditTransferListRequest({
+      CreditTransferAction.updateCreditTransferListRequest({
         "0x1234": CreditTransferData,
         "0x2345": AnotherCreditTransferData
       })

--- a/app/client/components/creditTransfer/creditTransferList.jsx
+++ b/app/client/components/creditTransfer/creditTransferList.jsx
@@ -5,7 +5,7 @@ import ReactTable from "react-table";
 
 import { TopRow, StyledSelect } from "../styledElements.js";
 
-import { modifyTransferRequest } from "../../reducers/creditTransfer/reducers";
+import { ModifyCreditTransferAction } from "../../reducers/creditTransfer/actions";
 
 import LoadingSpinner from "../loadingSpinner.jsx";
 import DateTime from "../dateTime.jsx";
@@ -24,8 +24,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    modifyTransferRequest: (body, path) =>
-      dispatch(modifyTransferRequest({ body, path }))
+    modifyTransferRequest: payload =>
+      dispatch(ModifyCreditTransferAction.modifyTransferRequest(payload))
   };
 };
 
@@ -145,7 +145,10 @@ class CreditTransferList extends React.Component {
 
   onNext() {
     this.get_selected_ids_array(this.state.credit_transfer_ids).map(id =>
-      this.props.modifyTransferRequest({ action: this.state.action }, id)
+      this.props.modifyTransferRequest({
+        body: { action: this.state.action },
+        path: id
+      })
     );
   }
 

--- a/app/client/components/creditTransfer/creditTransferList.jsx
+++ b/app/client/components/creditTransfer/creditTransferList.jsx
@@ -5,7 +5,7 @@ import ReactTable from "react-table";
 
 import { TopRow, StyledSelect } from "../styledElements.js";
 
-import { modifyTransferRequest } from "../../reducers/creditTransferReducer";
+import { modifyTransferRequest } from "../../reducers/creditTransfer/reducers";
 
 import LoadingSpinner from "../loadingSpinner.jsx";
 import DateTime from "../dateTime.jsx";

--- a/app/client/components/creditTransfer/userCell.jsx
+++ b/app/client/components/creditTransfer/userCell.jsx
@@ -2,19 +2,11 @@ import React from "react";
 import { connect } from "react-redux";
 
 import { Link } from "react-router-dom";
-import { modifyTransferRequest } from "../../reducers/creditTransfer/reducers";
 
 const mapStateToProps = state => {
   return {
     creditTransfers: state.creditTransfers,
     users: state.users
-  };
-};
-
-const mapDispatchToProps = dispatch => {
-  return {
-    modifyTransferRequest: (body, path) =>
-      dispatch(modifyTransferRequest({ body, path }))
   };
 };
 
@@ -47,5 +39,5 @@ class userCell extends React.Component {
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(userCell);

--- a/app/client/components/creditTransfer/userCell.jsx
+++ b/app/client/components/creditTransfer/userCell.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 
 import { Link } from "react-router-dom";
-import { modifyTransferRequest } from "../../reducers/creditTransferReducer";
+import { modifyTransferRequest } from "../../reducers/creditTransfer/reducers";
 
 const mapStateToProps = state => {
   return {

--- a/app/client/components/dashboard/userFunnelChart.jsx
+++ b/app/client/components/dashboard/userFunnelChart.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 
 import { HorizontalBar } from "react-chartjs-2";
-import { creditTransferList } from "../../reducers/creditTransferReducer";
+import { creditTransferList } from "../../reducers/creditTransfer/reducers";
 import { ModuleHeader } from "../styledElements.js";
 
 const mapStateToProps = state => {

--- a/app/client/components/management/newTransferManager.jsx
+++ b/app/client/components/management/newTransferManager.jsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { StyledButton, StyledSelect, ModuleBox } from "../styledElements";
 import AsyncButton from "./../AsyncButton.jsx";
 
-import { createTransferRequest } from "../../reducers/creditTransfer/reducers";
+import { CreditTransferAction } from "../../reducers/creditTransfer/actions";
 
 const mapStateToProps = state => {
   return {
@@ -18,7 +18,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    createTransferRequest: body => dispatch(createTransferRequest({ body }))
+    createTransferRequest: body =>
+      dispatch(CreditTransferAction.createTransferRequest({ body }))
   };
 };
 

--- a/app/client/components/management/newTransferManager.jsx
+++ b/app/client/components/management/newTransferManager.jsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { StyledButton, StyledSelect, ModuleBox } from "../styledElements";
 import AsyncButton from "./../AsyncButton.jsx";
 
-import { createTransferRequest } from "../../reducers/creditTransferReducer";
+import { createTransferRequest } from "../../reducers/creditTransfer/reducers";
 
 const mapStateToProps = state => {
   return {

--- a/app/client/components/pages/creditTransferListPage.jsx
+++ b/app/client/components/pages/creditTransferListPage.jsx
@@ -8,7 +8,7 @@ import { LightTheme } from "../theme.js";
 import CreditTransferListWithFilterWrapper from "../creditTransfer/creditTransferListWithFilterWrapper.jsx";
 import UploadButton from "../uploader/uploadButton.jsx";
 
-import { loadCreditTransferList } from "../../reducers/creditTransferReducer";
+import { loadCreditTransferList } from "../../reducers/creditTransfer/reducers";
 import organizationWrapper from "../organizationWrapper.jsx";
 
 const mapStateToProps = state => {

--- a/app/client/components/pages/creditTransferListPage.jsx
+++ b/app/client/components/pages/creditTransferListPage.jsx
@@ -8,7 +8,7 @@ import { LightTheme } from "../theme.js";
 import CreditTransferListWithFilterWrapper from "../creditTransfer/creditTransferListWithFilterWrapper.jsx";
 import UploadButton from "../uploader/uploadButton.jsx";
 
-import { loadCreditTransferList } from "../../reducers/creditTransfer/reducers";
+import { LoadCreditTransferAction } from "../../reducers/creditTransfer/actions";
 import organizationWrapper from "../organizationWrapper.jsx";
 
 const mapStateToProps = state => {
@@ -23,7 +23,9 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     loadCreditTransferList: (query, path) =>
-      dispatch(loadCreditTransferList({ query, path }))
+      dispatch(
+        LoadCreditTransferAction.loadCreditTransferListRequest({ query, path })
+      )
   };
 };
 

--- a/app/client/components/pages/dashboardPage.jsx
+++ b/app/client/components/pages/dashboardPage.jsx
@@ -3,9 +3,9 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { subscribe, unsubscribe } from "pusher-redux";
 
-import { PUSHER_CREDIT_TRANSFER } from "../../reducers/creditTransferReducer";
+import { PUSHER_CREDIT_TRANSFER } from "../../reducers/creditTransfer/reducers";
 import { LoginAction } from "../../reducers/auth/actions";
-import { loadCreditTransferList } from "../../reducers/creditTransferReducer";
+import { loadCreditTransferList } from "../../reducers/creditTransfer/reducers";
 import { loadCreditTransferFilters } from "../../reducers/creditTransferFilterReducer";
 
 import {

--- a/app/client/components/pages/dashboardPage.jsx
+++ b/app/client/components/pages/dashboardPage.jsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import styled from "styled-components";
 import { subscribe, unsubscribe } from "pusher-redux";
 
-import { PUSHER_CREDIT_TRANSFER } from "../../reducers/creditTransfer/reducers";
+import { CreditTransferActionTypes } from "../../reducers/creditTransfer/types";
 import { LoginAction } from "../../reducers/auth/actions";
 import { loadCreditTransferList } from "../../reducers/creditTransfer/reducers";
 import { loadCreditTransferFilters } from "../../reducers/creditTransferFilterReducer";
@@ -98,7 +98,7 @@ class DashboardPage extends React.Component {
     subscribe(
       pusher_channel,
       "credit_transfer",
-      PUSHER_CREDIT_TRANSFER,
+      CreditTransferActionTypes.PUSHER_CREDIT_TRANSFER,
       additionalParams
     );
 
@@ -112,7 +112,11 @@ class DashboardPage extends React.Component {
   }
 
   unsubscribe() {
-    unsubscribe("MainChannel", "credit_transfer", PUSHER_CREDIT_TRANSFER);
+    unsubscribe(
+      "MainChannel",
+      "credit_transfer",
+      CreditTransferActionTypes.PUSHER_CREDIT_TRANSFER
+    );
   }
 
   render() {

--- a/app/client/components/pages/dashboardPage.jsx
+++ b/app/client/components/pages/dashboardPage.jsx
@@ -4,8 +4,8 @@ import styled from "styled-components";
 import { subscribe, unsubscribe } from "pusher-redux";
 
 import { CreditTransferActionTypes } from "../../reducers/creditTransfer/types";
+import { LoadCreditTransferAction } from "../../reducers/creditTransfer/actions";
 import { LoginAction } from "../../reducers/auth/actions";
-import { loadCreditTransferList } from "../../reducers/creditTransfer/reducers";
 import { loadCreditTransferFilters } from "../../reducers/creditTransferFilterReducer";
 
 import {
@@ -39,8 +39,10 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     logout: () => dispatch(LoginAction.logout()),
-    loadCreditTransferList: (query, path) =>
-      dispatch(loadCreditTransferList({ query, path })),
+    loadCreditTransferList: query =>
+      dispatch(
+        LoadCreditTransferAction.loadCreditTransferListRequest({ query })
+      ),
     loadCreditTransferFilters: (query, path) =>
       dispatch(loadCreditTransferFilters({ query, path })),
     activateAccount: payload =>

--- a/app/client/components/transferAccount/transferAccountManager.jsx
+++ b/app/client/components/transferAccount/transferAccountManager.jsx
@@ -11,7 +11,6 @@ import NewTransferManager from "../management/newTransferManager.jsx";
 import DateTime from "../dateTime.jsx";
 
 import { editTransferAccount } from "../../reducers/transferAccountReducer";
-import { createTransferRequest } from "../../reducers/creditTransfer/reducers";
 import { formatMoney } from "../../utils";
 import { TransferAccountTypes } from "./types";
 
@@ -28,7 +27,6 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    createTransferRequest: payload => dispatch(createTransferRequest(payload)),
     editTransferAccountRequest: (body, path) =>
       dispatch(editTransferAccount({ body, path }))
   };
@@ -55,7 +53,6 @@ class TransferAccountManager extends React.Component {
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleClick = this.handleClick.bind(this);
-    this.createNewTransfer = this.createNewTransfer.bind(this);
     this.onSave = this.onSave.bind(this);
     this.onNewTransfer = this.onNewTransfer.bind(this);
   }
@@ -157,29 +154,6 @@ class TransferAccountManager extends React.Component {
 
   onNewTransfer() {
     this.handleClick();
-  }
-
-  createNewTransfer() {
-    if (this.state.transfer_amount > 0) {
-      var transfer_account_ids = this.props.transfer_account_id;
-      var transfer_amount = this.state.transfer_amount * 100;
-      var transfer_type = this.state.create_transfer_type;
-      var credit_transfer_type_filter = this.state.transfer_type;
-      const transfer_account_filter = this.props.vendors
-        ? "?account_type=vendor"
-        : "?account_type=beneficiary";
-      const credit_transfer_filter = `?transfer_account_ids=${transfer_account_ids}&transfer_type=${credit_transfer_type_filter}`;
-      var id = null;
-
-      this.props.createTransferRequest({
-        transfer_account_ids,
-        transfer_amount,
-        transfer_type,
-        credit_transfer_filter,
-        transfer_account_filter,
-        id
-      });
-    }
   }
 
   render() {

--- a/app/client/components/transferAccount/transferAccountManager.jsx
+++ b/app/client/components/transferAccount/transferAccountManager.jsx
@@ -11,7 +11,7 @@ import NewTransferManager from "../management/newTransferManager.jsx";
 import DateTime from "../dateTime.jsx";
 
 import { editTransferAccount } from "../../reducers/transferAccountReducer";
-import { createTransferRequest } from "../../reducers/creditTransferReducer";
+import { createTransferRequest } from "../../reducers/creditTransfer/reducers";
 import { formatMoney } from "../../utils";
 import { TransferAccountTypes } from "./types";
 

--- a/app/client/reducers/creditTransfer/actions.ts
+++ b/app/client/reducers/creditTransfer/actions.ts
@@ -1,0 +1,90 @@
+import { createAction, ActionsUnion } from "../../reduxUtils";
+import {
+  CreditTransfer,
+  CreditTransfers,
+  CreditTransferActionTypes,
+  LoadCreditTransferActionTypes,
+  ModifyCreditTransferActionTypes
+} from "./types";
+
+// ACTIONS
+export const loadCreditTransferListRequest = () => ({
+  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST
+});
+
+export const loadCreditTransferListSuccess = (
+  credit_transfers: CreditTransfers
+) => ({
+  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS,
+  credit_transfers
+});
+
+export const loadCreditTransferListFailure = (err: any) => ({
+  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_FAILURE as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_FAILURE,
+  error: err
+});
+
+export const LoadCreditTransferAction = {
+  loadCreditTransferListRequest,
+  loadCreditTransferListSuccess,
+  loadCreditTransferListFailure
+};
+
+export type LoadCreditTransferAction = ActionsUnion<
+  typeof LoadCreditTransferAction
+>;
+
+export const modifyTransferRequest = () => ({
+  type: ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST as typeof ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST
+});
+
+export const modifyTransferSuccess = (result: any) => ({
+  type: ModifyCreditTransferActionTypes.MODIFY_TRANSFER_SUCCESS as typeof ModifyCreditTransferActionTypes.MODIFY_TRANSFER_SUCCESS,
+  result
+});
+
+export const modifyTransferFailure = (error: any) => ({
+  type: ModifyCreditTransferActionTypes.MODIFY_TRANSFER_FAILURE as typeof ModifyCreditTransferActionTypes.MODIFY_TRANSFER_FAILURE,
+  error
+});
+
+export const ModifyCreditTransferAction = {
+  modifyTransferRequest,
+  modifyTransferSuccess,
+  modifyTransferFailure
+};
+
+export type ModifyCreditTransferAction = ActionsUnion<
+  typeof ModifyCreditTransferAction
+>;
+
+export const createTransferRequest = (payload: any) => ({
+  type: CreditTransferActionTypes.CREATE_TRANSFER_REQUEST as typeof CreditTransferActionTypes.CREATE_TRANSFER_REQUEST,
+  payload
+});
+
+export const createTransferSuccess = (payload: any) => ({
+  type: CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS as typeof CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS,
+  payload
+});
+
+export const createTransferFailure = (error: any) => ({
+  type: CreditTransferActionTypes.CREATE_TRANSFER_FAILURE as typeof CreditTransferActionTypes.CREATE_TRANSFER_FAILURE,
+  error
+});
+
+export const updateCreditTransferListRequest = (
+  credit_transfers: CreditTransfers
+) => ({
+  type: CreditTransferActionTypes.UPDATE_CREDIT_TRANSFER_LIST as typeof CreditTransferActionTypes.UPDATE_CREDIT_TRANSFER_LIST,
+  credit_transfers
+});
+
+export const CreditTransferAction = {
+  createTransferRequest,
+  createTransferSuccess,
+  createTransferFailure,
+  updateCreditTransferListRequest
+};
+
+export type CreditTransferAction = ActionsUnion<typeof CreditTransferAction>;

--- a/app/client/reducers/creditTransfer/actions.ts
+++ b/app/client/reducers/creditTransfer/actions.ts
@@ -12,11 +12,8 @@ export const loadCreditTransferListRequest = () => ({
   type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST
 });
 
-export const loadCreditTransferListSuccess = (
-  credit_transfers: CreditTransfers
-) => ({
-  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS,
-  credit_transfers
+export const loadCreditTransferListSuccess = () => ({
+  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS
 });
 
 export const loadCreditTransferListFailure = (err: any) => ({
@@ -63,9 +60,8 @@ export const createTransferRequest = (payload: any) => ({
   payload
 });
 
-export const createTransferSuccess = (payload: any) => ({
-  type: CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS as typeof CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS,
-  payload
+export const createTransferSuccess = () => ({
+  type: CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS as typeof CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS
 });
 
 export const createTransferFailure = (error: any) => ({

--- a/app/client/reducers/creditTransfer/actions.ts
+++ b/app/client/reducers/creditTransfer/actions.ts
@@ -1,86 +1,67 @@
 import { createAction, ActionsUnion } from "../../reduxUtils";
 import {
-  CreditTransfer,
   CreditTransfers,
   CreditTransferActionTypes,
   LoadCreditTransferActionTypes,
-  ModifyCreditTransferActionTypes
+  ModifyCreditTransferActionTypes,
+  LoadCreditTransferPayload,
+  ModifyCreditTransferRequestPayload,
+  CreateCreditTransferPayload,
+  ModifyCreditTransferPayload
 } from "./types";
 
-// ACTIONS
-export const loadCreditTransferListRequest = () => ({
-  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST
-});
-
-export const loadCreditTransferListSuccess = () => ({
-  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS
-});
-
-export const loadCreditTransferListFailure = (err: any) => ({
-  type: LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_FAILURE as typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_FAILURE,
-  error: err
-});
-
 export const LoadCreditTransferAction = {
-  loadCreditTransferListRequest,
-  loadCreditTransferListSuccess,
-  loadCreditTransferListFailure
+  loadCreditTransferListRequest: (payload: LoadCreditTransferPayload) =>
+    createAction(
+      LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST,
+      payload
+    ),
+  loadCreditTransferListSuccess: () =>
+    createAction(
+      LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS
+    ),
+  loadCreditTransferListFailure: (err: string) =>
+    createAction(
+      LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_FAILURE,
+      err
+    )
 };
 
 export type LoadCreditTransferAction = ActionsUnion<
   typeof LoadCreditTransferAction
 >;
 
-export const modifyTransferRequest = () => ({
-  type: ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST as typeof ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST
-});
-
-export const modifyTransferSuccess = (result: any) => ({
-  type: ModifyCreditTransferActionTypes.MODIFY_TRANSFER_SUCCESS as typeof ModifyCreditTransferActionTypes.MODIFY_TRANSFER_SUCCESS,
-  result
-});
-
-export const modifyTransferFailure = (error: any) => ({
-  type: ModifyCreditTransferActionTypes.MODIFY_TRANSFER_FAILURE as typeof ModifyCreditTransferActionTypes.MODIFY_TRANSFER_FAILURE,
-  error
-});
-
 export const ModifyCreditTransferAction = {
-  modifyTransferRequest,
-  modifyTransferSuccess,
-  modifyTransferFailure
+  modifyTransferRequest: (payload: ModifyCreditTransferRequestPayload) =>
+    createAction(
+      ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST,
+      payload
+    ),
+  modifyTransferSuccess: (payload: ModifyCreditTransferPayload) =>
+    createAction(
+      ModifyCreditTransferActionTypes.MODIFY_TRANSFER_SUCCESS,
+      payload
+    ),
+  modifyTransferFailure: (err: string) =>
+    createAction(ModifyCreditTransferActionTypes.MODIFY_TRANSFER_FAILURE, err)
 };
 
 export type ModifyCreditTransferAction = ActionsUnion<
   typeof ModifyCreditTransferAction
 >;
 
-export const createTransferRequest = (payload: any) => ({
-  type: CreditTransferActionTypes.CREATE_TRANSFER_REQUEST as typeof CreditTransferActionTypes.CREATE_TRANSFER_REQUEST,
-  payload
-});
-
-export const createTransferSuccess = () => ({
-  type: CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS as typeof CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS
-});
-
-export const createTransferFailure = (error: any) => ({
-  type: CreditTransferActionTypes.CREATE_TRANSFER_FAILURE as typeof CreditTransferActionTypes.CREATE_TRANSFER_FAILURE,
-  error
-});
-
-export const updateCreditTransferListRequest = (
-  credit_transfers: CreditTransfers
-) => ({
-  type: CreditTransferActionTypes.UPDATE_CREDIT_TRANSFER_LIST as typeof CreditTransferActionTypes.UPDATE_CREDIT_TRANSFER_LIST,
-  credit_transfers
-});
-
 export const CreditTransferAction = {
-  createTransferRequest,
-  createTransferSuccess,
-  createTransferFailure,
-  updateCreditTransferListRequest
+  createTransferRequest: (payload: CreateCreditTransferPayload) =>
+    createAction(CreditTransferActionTypes.CREATE_TRANSFER_REQUEST, payload),
+  createTransferSuccess: () =>
+    createAction(CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS),
+  createTransferFailure: (err: string) =>
+    createAction(CreditTransferActionTypes.CREATE_TRANSFER_FAILURE, err),
+  updateCreditTransferListRequest: (credit_transfers: CreditTransfers) =>
+    createAction(
+      CreditTransferActionTypes.UPDATE_CREDIT_TRANSFER_LIST,
+      credit_transfers
+    )
 };
 
 export type CreditTransferAction = ActionsUnion<typeof CreditTransferAction>;

--- a/app/client/reducers/creditTransfer/reducers.ts
+++ b/app/client/reducers/creditTransfer/reducers.ts
@@ -1,27 +1,20 @@
 import { combineReducers } from "redux";
-import { DEEEEEEP } from "../utils";
+import { DEEEEEEP } from "../../utils";
+import {
+  CreditTransferActionTypes,
+  LoadCreditTransferActionTypes,
+  ModifyCreditTransferActionTypes
+} from "./types";
 
-export const UPDATE_CREDIT_TRANSFER_LIST = "UPDATE_CREDIT_TRANSFER_LIST";
+import {
+  CreditTransferAction,
+  LoadCreditTransferAction,
+  ModifyCreditTransferAction
+} from "./actions";
 
-export const LOAD_CREDIT_TRANSFER_LIST_REQUEST =
-  "LOAD_CREDIT_TRANSFER_LIST_REQUEST";
-export const LOAD_CREDIT_TRANSFER_LIST_SUCCESS =
-  "LOAD_CREDIT_TRANSFER_LIST_SUCCESS";
-export const LOAD_CREDIT_TRANSFER_LIST_FAILURE =
-  "LOAD_CREDIT_TRANSFER_LIST_FAILURE";
-export const PUSHER_CREDIT_TRANSFER = "PUSHER_CREDIT_TRANSFER";
-
-export const MODIFY_TRANSFER_REQUEST = "MODIFY_TRANSFER_REQUEST";
-export const MODIFY_TRANSFER_SUCCESS = "MODIFY_TRANSFER_SUCCESS";
-export const MODIFY_TRANSFER_FAILURE = "MODIFY_TRANSFER_FAILURE";
-
-export const CREATE_TRANSFER_REQUEST = "CREATE_TRANSFER_REQUEST";
-export const CREATE_TRANSFER_SUCCESS = "CREATE_TRANSFER_SUCCESS";
-export const CREATE_TRANSFER_FAILURE = "CREATE_TRANSFER_FAILURE";
-
-const byId = (state = {}, action) => {
+export const byId = (state = {}, action: CreditTransferAction) => {
   switch (action.type) {
-    case UPDATE_CREDIT_TRANSFER_LIST:
+    case CreditTransferActionTypes.UPDATE_CREDIT_TRANSFER_LIST:
       Object.keys(action.credit_transfers).map(id => {
         let transfer = action.credit_transfers[id];
         if (
@@ -47,15 +40,18 @@ const initialLoadStatusState = {
   success: false
 };
 
-const loadStatus = (state = initialLoadStatusState, action) => {
+const loadStatus = (
+  state = initialLoadStatusState,
+  action: LoadCreditTransferAction
+) => {
   switch (action.type) {
-    case LOAD_CREDIT_TRANSFER_LIST_REQUEST:
+    case LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST:
       return { ...state, isRequesting: true };
 
-    case LOAD_CREDIT_TRANSFER_LIST_SUCCESS:
+    case LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_SUCCESS:
       return { ...state, isRequesting: false, success: true };
 
-    case LOAD_CREDIT_TRANSFER_LIST_FAILURE:
+    case LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_FAILURE:
       return { ...state, isRequesting: false, error: action.error };
 
     default:
@@ -63,24 +59,34 @@ const loadStatus = (state = initialLoadStatusState, action) => {
   }
 };
 
-const initialModifyStatusState = {
+const initialModifyStatusState: ModifyStatusState = {
   isRequesting: false,
   error: null,
   success: null
 };
 
-export const modifyStatus = (state = initialModifyStatusState, action) => {
+interface ModifyStatusState {
+  isRequesting: boolean;
+  error?: string | null;
+  success: boolean | null;
+  data?: any;
+}
+
+export const modifyStatus = (
+  state = initialModifyStatusState,
+  action: ModifyCreditTransferAction
+): ModifyStatusState => {
   switch (action.type) {
-    case MODIFY_TRANSFER_REQUEST:
+    case ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST:
       return { ...state, isRequesting: true, error: null, success: false };
-    case MODIFY_TRANSFER_SUCCESS:
+    case ModifyCreditTransferActionTypes.MODIFY_TRANSFER_SUCCESS:
       return {
         ...state,
         isRequesting: false,
         data: action.result.data,
         success: true
       };
-    case MODIFY_TRANSFER_FAILURE:
+    case ModifyCreditTransferActionTypes.MODIFY_TRANSFER_FAILURE:
       return { ...state, isRequesting: false, error: action.error };
     default:
       return state;
@@ -93,13 +99,16 @@ const initialCreateStatusState = {
   success: false
 };
 
-export const createStatus = (state = initialCreateStatusState, action) => {
+export const createStatus = (
+  state = initialCreateStatusState,
+  action: CreditTransferAction
+) => {
   switch (action.type) {
-    case CREATE_TRANSFER_REQUEST:
+    case CreditTransferActionTypes.CREATE_TRANSFER_REQUEST:
       return { ...state, isRequesting: true, error: null, success: false };
-    case CREATE_TRANSFER_SUCCESS:
+    case CreditTransferActionTypes.CREATE_TRANSFER_SUCCESS:
       return { ...state, isRequesting: false, success: true };
-    case CREATE_TRANSFER_FAILURE:
+    case CreditTransferActionTypes.CREATE_TRANSFER_FAILURE:
       return { ...state, isRequesting: false, error: action.error };
     default:
       return state;
@@ -111,20 +120,4 @@ export const creditTransfers = combineReducers({
   loadStatus,
   createStatus,
   modifyStatus
-});
-
-// ACTIONS
-export const loadCreditTransferList = payload => ({
-  type: LOAD_CREDIT_TRANSFER_LIST_REQUEST,
-  payload
-});
-
-export const modifyTransferRequest = payload => ({
-  type: MODIFY_TRANSFER_REQUEST,
-  payload
-});
-
-export const createTransferRequest = payload => ({
-  type: CREATE_TRANSFER_REQUEST,
-  payload
 });

--- a/app/client/reducers/creditTransfer/reducers.ts
+++ b/app/client/reducers/creditTransfer/reducers.ts
@@ -15,8 +15,8 @@ import {
 export const byId = (state = {}, action: CreditTransferAction) => {
   switch (action.type) {
     case CreditTransferActionTypes.UPDATE_CREDIT_TRANSFER_LIST:
-      Object.keys(action.credit_transfers).map(id => {
-        let transfer = action.credit_transfers[id];
+      Object.keys(action.payload).map(id => {
+        let transfer = action.payload[id];
         if (
           transfer.transfer_subtype !== null &&
           typeof transfer.transfer_subtype !== "undefined"
@@ -28,22 +28,25 @@ export const byId = (state = {}, action: CreditTransferAction) => {
           }
         }
       });
-      return DEEEEEEP(state, action.credit_transfers);
+      return DEEEEEEP(state, action.payload);
     default:
       return state;
   }
 };
 
-const initialLoadStatusState = {
+interface RequestingState {
+  isRequesting: boolean;
+  success: boolean;
+  error: null | string;
+}
+
+const initialState: RequestingState = {
   isRequesting: false,
-  error: null,
-  success: false
+  success: false,
+  error: null
 };
 
-const loadStatus = (
-  state = initialLoadStatusState,
-  action: LoadCreditTransferAction
-) => {
+const loadStatus = (state = initialState, action: LoadCreditTransferAction) => {
   switch (action.type) {
     case LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST:
       return { ...state, isRequesting: true };
@@ -83,7 +86,7 @@ export const modifyStatus = (
       return {
         ...state,
         isRequesting: false,
-        data: action.result.data,
+        data: action.payload.data,
         success: true
       };
     case ModifyCreditTransferActionTypes.MODIFY_TRANSFER_FAILURE:
@@ -93,16 +96,10 @@ export const modifyStatus = (
   }
 };
 
-const initialCreateStatusState = {
-  isRequesting: false,
-  error: null,
-  success: false
-};
-
 export const createStatus = (
-  state = initialCreateStatusState,
+  state = initialState,
   action: CreditTransferAction
-) => {
+): RequestingState => {
   switch (action.type) {
     case CreditTransferActionTypes.CREATE_TRANSFER_REQUEST:
       return { ...state, isRequesting: true, error: null, success: false };

--- a/app/client/reducers/creditTransfer/types.ts
+++ b/app/client/reducers/creditTransfer/types.ts
@@ -1,0 +1,31 @@
+export enum CreditTransferActionTypes {
+  UPDATE_CREDIT_TRANSFER_LIST = "UPDATE_CREDIT_TRANSFER_LIST",
+  PUSHER_CREDIT_TRANSFER = "PUSHER_CREDIT_TRANSFER",
+  CREATE_TRANSFER_REQUEST = "CREATE_TRANSFER_REQUEST",
+  CREATE_TRANSFER_SUCCESS = "CREATE_TRANSFER_SUCCESS",
+  CREATE_TRANSFER_FAILURE = "CREATE_TRANSFER_FAILURE"
+}
+
+export enum LoadCreditTransferActionTypes {
+  LOAD_CREDIT_TRANSFER_LIST_REQUEST = "LOAD_CREDIT_TRANSFER_LIST_REQUEST",
+  LOAD_CREDIT_TRANSFER_LIST_SUCCESS = "LOAD_CREDIT_TRANSFER_LIST_SUCCESS",
+  LOAD_CREDIT_TRANSFER_LIST_FAILURE = "LOAD_CREDIT_TRANSFER_LIST_FAILURE"
+}
+
+export enum ModifyCreditTransferActionTypes {
+  MODIFY_TRANSFER_REQUEST = "MODIFY_TRANSFER_REQUEST",
+  MODIFY_TRANSFER_SUCCESS = "MODIFY_TRANSFER_SUCCESS",
+  MODIFY_TRANSFER_FAILURE = "MODIFY_TRANSFER_FAILURE"
+}
+
+// TODO verify this is the actual format
+export interface CreditTransfer {
+  transfer_subtype: string;
+  transfer_type: string;
+}
+
+// TODO we should only need one of these keys
+export interface CreditTransfers {
+  [key: number]: CreditTransfer;
+  [key: string]: CreditTransfer;
+}

--- a/app/client/reducers/creditTransfer/types.ts
+++ b/app/client/reducers/creditTransfer/types.ts
@@ -1,3 +1,6 @@
+import { TransferAccount } from "../transferAccount/types";
+import { User } from "../user/types";
+
 export enum CreditTransferActionTypes {
   UPDATE_CREDIT_TRANSFER_LIST = "UPDATE_CREDIT_TRANSFER_LIST",
   PUSHER_CREDIT_TRANSFER = "PUSHER_CREDIT_TRANSFER",
@@ -18,14 +21,70 @@ export enum ModifyCreditTransferActionTypes {
   MODIFY_TRANSFER_FAILURE = "MODIFY_TRANSFER_FAILURE"
 }
 
-// TODO verify this is the actual format
 export interface CreditTransfer {
+  attached_images?: object;
+  authorising_user_email?: string;
+  blockchain_status?: string;
+  blockchain_task_uuid?: string;
+  created?: string;
+  id?: number;
+  is_sender?: boolean;
+  lat?: number;
+  lng?: number;
+  recipient_transfer_account?: TransferAccount;
+  recipient_user?: User;
+  resolved?: string;
+  sender_transfer_account?: TransferAccount;
+  sender_transfer_account_id?: number;
+  sender_user?: User;
+  token?: {
+    id: number;
+    symbol: string;
+  };
+  transfer_amount: number;
+  transfer_metadata?: null | object;
+  transfer_status: string;
   transfer_subtype: string;
   transfer_type: string;
+  transfer_use?: null | object;
+  updated?: string;
+  uuid?: null | string;
 }
 
 // TODO we should only need one of these keys
 export interface CreditTransfers {
   [key: number]: CreditTransfer;
+
   [key: string]: CreditTransfer;
+}
+
+export interface LoadCreditTransferPayload {
+  query: {
+    get_stats: boolean;
+    transfer_type: string;
+    per_page: number;
+    page: number;
+  };
+}
+
+export interface ModifyCreditTransferRequestPayload {
+  body: {
+    action: string;
+  };
+  path: number;
+}
+
+export interface ModifyCreditTransferPayload {
+  data: CreditTransfer;
+  message: string;
+}
+
+export interface CreateCreditTransferPayload {
+  body: {
+    is_bulk?: boolean;
+    recipient_transfer_accounts_ids: object;
+    transfer_amount: number;
+    target_balance?: number;
+    transfer_type: string;
+  };
 }

--- a/app/client/reducers/rootReducer.ts
+++ b/app/client/reducers/rootReducer.ts
@@ -17,7 +17,7 @@ import {
 } from "./spreadsheetReducer";
 import { ExportReducer } from "./export/reducers";
 import { message } from "./message/reducers";
-import { creditTransfers } from "./creditTransferReducer";
+import { creditTransfers } from "./creditTransfer/reducers";
 import { transferAccounts } from "./transferAccountReducer";
 import { users } from "./user/reducers";
 import { filters } from "./filter/reducers";

--- a/app/client/reducers/transferAccount/types.ts
+++ b/app/client/reducers/transferAccount/types.ts
@@ -4,3 +4,15 @@ interface TransferAccount {}
 export interface TransferAccountByIDs {
   [key: number]: TransferAccount;
 }
+
+export interface SingularTransferAccountData {
+  transfer_account: string;
+}
+
+export interface MultipleTransferAccountData {
+  transfer_accounts: string[];
+}
+
+export type TransferAccountData =
+  | SingularTransferAccountData
+  | MultipleTransferAccountData;

--- a/app/client/reducers/transferAccount/types.ts
+++ b/app/client/reducers/transferAccount/types.ts
@@ -1,5 +1,5 @@
 //todo: complete when transfer account reducer converted to typescript
-interface TransferAccount {}
+export interface TransferAccount {}
 
 export interface TransferAccountByIDs {
   [key: number]: TransferAccount;

--- a/app/client/sagas/creditTransferSagas.js
+++ b/app/client/sagas/creditTransferSagas.js
@@ -2,10 +2,6 @@ import { put, takeEvery, call, all } from "redux-saga/effects";
 import { normalize } from "normalizr";
 
 import {
-  PUSHER_CREDIT_TRANSFER // TODO UNUSED?
-} from "../reducers/creditTransfer/reducers";
-
-import {
   LoadCreditTransferActionTypes,
   ModifyCreditTransferActionTypes,
   CreditTransferActionTypes
@@ -133,7 +129,10 @@ function* loadPusherCreditTransfer(pusher_data) {
 }
 
 function* watchPusherCreditTransfer() {
-  yield takeEvery(PUSHER_CREDIT_TRANSFER, loadPusherCreditTransfer);
+  yield takeEvery(
+    CreditTransferActionTypes.PUSHER_CREDIT_TRANSFER,
+    loadPusherCreditTransfer
+  );
 }
 
 function* modifyTransfer({ payload }) {

--- a/app/client/sagas/creditTransferSagas.js
+++ b/app/client/sagas/creditTransferSagas.js
@@ -8,16 +8,9 @@ import {
 } from "../reducers/creditTransfer/types";
 
 import {
-  updateCreditTransferListRequest,
-  loadCreditTransferListRequest,
-  loadCreditTransferListSuccess,
-  loadCreditTransferListFailure,
-  modifyTransferRequest,
-  modifyTransferSuccess,
-  modifyTransferFailure,
-  createTransferRequest,
-  createTransferSuccess,
-  createTransferFailure
+  CreditTransferAction,
+  LoadCreditTransferAction,
+  ModifyCreditTransferAction
 } from "../reducers/creditTransfer/actions";
 
 import {
@@ -87,7 +80,9 @@ function* updateStateFromCreditTransfer(result) {
   const credit_transfers = normalizedData.entities.credit_transfers;
 
   if (credit_transfers) {
-    yield put(updateCreditTransferListRequest(credit_transfers));
+    yield put(
+      CreditTransferAction.updateCreditTransferListRequest(credit_transfers)
+    );
   }
 }
 
@@ -97,11 +92,11 @@ function* loadCreditTransferList({ payload }) {
 
     yield call(updateStateFromCreditTransfer, credit_load_result);
 
-    yield put(loadCreditTransferListSuccess());
+    yield put(LoadCreditTransferAction.loadCreditTransferListSuccess());
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put(loadCreditTransferListFailure(error));
+    yield put(LoadCreditTransferAction.loadCreditTransferListFailure(error));
 
     yield put(
       MessageAction.addMessage({ error: true, message: error.message })
@@ -120,11 +115,11 @@ function* loadPusherCreditTransfer(pusher_data) {
   try {
     yield call(updateStateFromCreditTransfer, pusher_data);
 
-    yield put(loadCreditTransferListSuccess());
+    yield put(LoadCreditTransferAction.loadCreditTransferListSuccess());
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put(loadCreditTransferListFailure(error));
+    yield put(LoadCreditTransferAction.loadCreditTransferListFailure(error));
   }
 }
 
@@ -141,7 +136,7 @@ function* modifyTransfer({ payload }) {
 
     yield call(updateStateFromCreditTransfer, result);
 
-    yield put(modifyTransferSuccess());
+    yield put(ModifyCreditTransferAction.modifyTransferSuccess());
 
     yield put(
       MessageAction.addMessage({ error: false, message: result.message })
@@ -149,7 +144,7 @@ function* modifyTransfer({ payload }) {
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put(modifyTransferFailure(error));
+    yield put(ModifyCreditTransferAction.modifyTransferFailure(error));
 
     yield put(
       MessageAction.addMessage({ error: true, message: error.message })
@@ -170,11 +165,11 @@ function* createTransfer({ payload }) {
 
     yield call(updateStateFromCreditTransfer, result);
 
-    yield put(createTransferSuccess());
+    yield put(CreditTransferAction.createTransferSuccess());
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put(createTransferFailure(error));
+    yield put(CreditTransferAction.createTransferFailure(error));
 
     yield put(
       MessageAction.addMessage({ error: true, message: error.message })

--- a/app/client/sagas/creditTransferSagas.js
+++ b/app/client/sagas/creditTransferSagas.js
@@ -2,18 +2,27 @@ import { put, takeEvery, call, all } from "redux-saga/effects";
 import { normalize } from "normalizr";
 
 import {
-  PUSHER_CREDIT_TRANSFER,
-  UPDATE_CREDIT_TRANSFER_LIST,
-  LOAD_CREDIT_TRANSFER_LIST_REQUEST,
-  LOAD_CREDIT_TRANSFER_LIST_SUCCESS,
-  LOAD_CREDIT_TRANSFER_LIST_FAILURE,
-  MODIFY_TRANSFER_FAILURE,
-  MODIFY_TRANSFER_REQUEST,
-  MODIFY_TRANSFER_SUCCESS,
-  CREATE_TRANSFER_REQUEST,
-  CREATE_TRANSFER_SUCCESS,
-  CREATE_TRANSFER_FAILURE
-} from "../reducers/creditTransferReducer.js";
+  PUSHER_CREDIT_TRANSFER // TODO UNUSED?
+} from "../reducers/creditTransfer/reducers";
+
+import {
+  LoadCreditTransferActionTypes,
+  ModifyCreditTransferActionTypes,
+  CreditTransferActionTypes
+} from "../reducers/creditTransfer/types";
+
+import {
+  updateCreditTransferListRequest,
+  loadCreditTransferListRequest,
+  loadCreditTransferListSuccess,
+  loadCreditTransferListFailure,
+  modifyTransferRequest,
+  modifyTransferSuccess,
+  modifyTransferFailure,
+  createTransferRequest,
+  createTransferSuccess,
+  createTransferFailure
+} from "../reducers/creditTransfer/actions";
 
 import {
   DEEP_UPDATE_TRANSFER_ACCOUNTS,
@@ -82,7 +91,7 @@ function* updateStateFromCreditTransfer(result) {
   const credit_transfers = normalizedData.entities.credit_transfers;
 
   if (credit_transfers) {
-    yield put({ type: UPDATE_CREDIT_TRANSFER_LIST, credit_transfers });
+    yield put(updateCreditTransferListRequest(credit_transfers));
   }
 }
 
@@ -92,11 +101,11 @@ function* loadCreditTransferList({ payload }) {
 
     yield call(updateStateFromCreditTransfer, credit_load_result);
 
-    yield put({ type: LOAD_CREDIT_TRANSFER_LIST_SUCCESS });
+    yield put(loadCreditTransferListSuccess());
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put({ type: LOAD_CREDIT_TRANSFER_LIST_FAILURE, error: error });
+    yield put(loadCreditTransferListFailure(error));
 
     yield put(
       MessageAction.addMessage({ error: true, message: error.message })
@@ -105,18 +114,21 @@ function* loadCreditTransferList({ payload }) {
 }
 
 function* watchLoadCreditTransferList() {
-  yield takeEvery(LOAD_CREDIT_TRANSFER_LIST_REQUEST, loadCreditTransferList);
+  yield takeEvery(
+    LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST,
+    loadCreditTransferList
+  );
 }
 
 function* loadPusherCreditTransfer(pusher_data) {
   try {
     yield call(updateStateFromCreditTransfer, pusher_data);
 
-    yield put({ type: LOAD_CREDIT_TRANSFER_LIST_SUCCESS });
+    yield put(loadCreditTransferListSuccess());
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put({ type: LOAD_CREDIT_TRANSFER_LIST_FAILURE, error: error });
+    yield put(loadCreditTransferListFailure(error));
   }
 }
 
@@ -130,7 +142,7 @@ function* modifyTransfer({ payload }) {
 
     yield call(updateStateFromCreditTransfer, result);
 
-    yield put({ type: MODIFY_TRANSFER_SUCCESS });
+    yield put(modifyTransferSuccess());
 
     yield put(
       MessageAction.addMessage({ error: false, message: result.message })
@@ -138,7 +150,7 @@ function* modifyTransfer({ payload }) {
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put({ type: MODIFY_TRANSFER_FAILURE, error: error });
+    yield put(modifyTransferFailure(error));
 
     yield put(
       MessageAction.addMessage({ error: true, message: error.message })
@@ -147,7 +159,10 @@ function* modifyTransfer({ payload }) {
 }
 
 function* watchModifyTransfer() {
-  yield takeEvery(MODIFY_TRANSFER_REQUEST, modifyTransfer);
+  yield takeEvery(
+    ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST,
+    modifyTransfer
+  );
 }
 
 function* createTransfer({ payload }) {
@@ -156,11 +171,11 @@ function* createTransfer({ payload }) {
 
     yield call(updateStateFromCreditTransfer, result);
 
-    yield put({ type: CREATE_TRANSFER_SUCCESS });
+    yield put(createTransferSuccess());
   } catch (fetch_error) {
     const error = yield call(handleError, fetch_error);
 
-    yield put({ type: CREATE_TRANSFER_FAILURE, error: error });
+    yield put(createTransferFailure(error));
 
     yield put(
       MessageAction.addMessage({ error: true, message: error.message })
@@ -169,7 +184,10 @@ function* createTransfer({ payload }) {
 }
 
 function* watchCreateTransfer() {
-  yield takeEvery(CREATE_TRANSFER_REQUEST, createTransfer);
+  yield takeEvery(
+    CreditTransferActionTypes.CREATE_TRANSFER_REQUEST,
+    createTransfer
+  );
 }
 
 export default function* credit_transferSagas() {

--- a/app/client/sagas/creditTransferSagas.ts
+++ b/app/client/sagas/creditTransferSagas.ts
@@ -29,7 +29,14 @@ import { MessageAction } from "../reducers/message/actions";
 import { UserListAction } from "../reducers/user/actions";
 import { MetricAction } from "../reducers/metric/actions";
 
-function* updateStateFromCreditTransfer(result) {
+interface CreditLoadApiResult {
+  is_create: boolean;
+  data: any;
+  message: string;
+  bulk_responses: any[];
+}
+
+function* updateStateFromCreditTransfer(result: CreditLoadApiResult) {
   //Schema expects a list of credit transfer objects
   let credit_transfer_list = [];
   if (result.data.credit_transfers) {
@@ -86,7 +93,12 @@ function* updateStateFromCreditTransfer(result) {
   }
 }
 
-function* loadCreditTransferList({ payload }) {
+interface CreditTransferListAPIResult {
+  type: typeof LoadCreditTransferActionTypes.LOAD_CREDIT_TRANSFER_LIST_REQUEST;
+  payload: any;
+}
+
+function* loadCreditTransferList({ payload }: CreditTransferListAPIResult) {
   try {
     const credit_load_result = yield call(loadCreditTransferListAPI, payload);
 
@@ -111,7 +123,7 @@ function* watchLoadCreditTransferList() {
   );
 }
 
-function* loadPusherCreditTransfer(pusher_data) {
+function* loadPusherCreditTransfer(pusher_data: any) {
   try {
     yield call(updateStateFromCreditTransfer, pusher_data);
 
@@ -130,13 +142,18 @@ function* watchPusherCreditTransfer() {
   );
 }
 
-function* modifyTransfer({ payload }) {
+function* modifyTransfer({
+  payload
+}: {
+  type: typeof ModifyCreditTransferActionTypes.MODIFY_TRANSFER_REQUEST;
+  payload: any;
+}) {
   try {
     const result = yield call(modifyTransferAPI, payload);
 
     yield call(updateStateFromCreditTransfer, result);
 
-    yield put(ModifyCreditTransferAction.modifyTransferSuccess());
+    yield put(ModifyCreditTransferAction.modifyTransferSuccess(result));
 
     yield put(
       MessageAction.addMessage({ error: false, message: result.message })
@@ -159,7 +176,16 @@ function* watchModifyTransfer() {
   );
 }
 
-function* createTransfer({ payload }) {
+interface CreditTransferAPIResult {
+  payload: any;
+}
+
+function* createTransfer({
+  payload
+}: {
+  type: typeof CreditTransferActionTypes.CREATE_TRANSFER_REQUEST;
+  payload: any;
+}) {
   try {
     const result = yield call(newTransferAPI, payload);
 

--- a/app/client/sagas/creditTransferSagas.ts
+++ b/app/client/sagas/creditTransferSagas.ts
@@ -16,13 +16,13 @@ import {
 import {
   DEEP_UPDATE_TRANSFER_ACCOUNTS,
   UPDATE_TRANSFER_ACCOUNTS_CREDIT_TRANSFERS
-} from "../reducers/transferAccountReducer.js";
+} from "../reducers/transferAccountReducer";
 
 import {
   loadCreditTransferListAPI,
   modifyTransferAPI,
   newTransferAPI
-} from "../api/creditTransferAPI.js";
+} from "../api/creditTransferAPI";
 import { creditTransferSchema } from "../schemas";
 import { handleError } from "../utils";
 import { MessageAction } from "../reducers/message/actions";

--- a/app/client/sagas/transferAccountSagas.js
+++ b/app/client/sagas/transferAccountSagas.js
@@ -14,7 +14,7 @@ import {
   EDIT_TRANSFER_ACCOUNT_FAILURE
 } from "../reducers/transferAccountReducer.js";
 
-import { UPDATE_CREDIT_TRANSFER_LIST } from "../reducers/creditTransferReducer";
+import { updateCreditTransferListRequest } from "../reducers/creditTransfer/reducers";
 
 import {
   loadTransferAccountListAPI,
@@ -43,18 +43,12 @@ function* updateStateFromTransferAccount(data) {
 
   const credit_sends = normalizedData.entities.credit_sends;
   if (credit_sends) {
-    yield put({
-      type: UPDATE_CREDIT_TRANSFER_LIST,
-      credit_transfers: credit_sends
-    });
+    yield put(updateCreditTransferListRequest(credit_sends));
   }
 
   const credit_receives = normalizedData.entities.credit_receives;
   if (credit_receives) {
-    yield put({
-      type: UPDATE_CREDIT_TRANSFER_LIST,
-      credit_transfers: credit_receives
-    });
+    yield put(updateCreditTransferListRequest(credit_receives));
   }
 
   const transfer_accounts = normalizedData.entities.transfer_accounts;

--- a/app/client/sagas/transferAccountSagas.ts
+++ b/app/client/sagas/transferAccountSagas.ts
@@ -1,5 +1,5 @@
 import { put, takeEvery, call, all, delay } from "redux-saga/effects";
-import { arrayOf, normalize } from "normalizr";
+import { normalize } from "normalizr";
 import { handleError } from "../utils";
 
 import { transferAccountSchema } from "../schemas";
@@ -14,7 +14,13 @@ import {
   EDIT_TRANSFER_ACCOUNT_FAILURE
 } from "../reducers/transferAccountReducer.js";
 
-import { updateCreditTransferListRequest } from "../reducers/creditTransfer/reducers";
+import {
+  TransferAccountData,
+  SingularTransferAccountData,
+  MultipleTransferAccountData
+} from "../reducers/transferAccount/types";
+
+import { CreditTransferAction } from "../reducers/creditTransfer/actions";
 
 import {
   loadTransferAccountListAPI,
@@ -24,12 +30,15 @@ import {
 import { MessageAction } from "../reducers/message/actions";
 import { UserListAction } from "../reducers/user/actions";
 
-function* updateStateFromTransferAccount(data) {
+function* updateStateFromTransferAccount(data: TransferAccountData) {
   //Schema expects a list of transfer account objects
-  if (data.transfer_accounts) {
-    var transfer_account_list = data.transfer_accounts;
+  if ((data as MultipleTransferAccountData).transfer_accounts) {
+    var transfer_account_list = (data as MultipleTransferAccountData)
+      .transfer_accounts;
   } else {
-    transfer_account_list = [data.transfer_account];
+    transfer_account_list = [
+      (data as SingularTransferAccountData).transfer_account
+    ];
   }
   const normalizedData = normalize(
     transfer_account_list,
@@ -43,12 +52,16 @@ function* updateStateFromTransferAccount(data) {
 
   const credit_sends = normalizedData.entities.credit_sends;
   if (credit_sends) {
-    yield put(updateCreditTransferListRequest(credit_sends));
+    yield put(
+      CreditTransferAction.updateCreditTransferListRequest(credit_sends)
+    );
   }
 
   const credit_receives = normalizedData.entities.credit_receives;
   if (credit_receives) {
-    yield put(updateCreditTransferListRequest(credit_receives));
+    yield put(
+      CreditTransferAction.updateCreditTransferListRequest(credit_receives)
+    );
   }
 
   const transfer_accounts = normalizedData.entities.transfer_accounts;
@@ -57,8 +70,13 @@ function* updateStateFromTransferAccount(data) {
   }
 }
 
+interface TransferAccountLoadApiResult {
+  type: typeof LOAD_TRANSFER_ACCOUNTS_REQUEST;
+  payload: any;
+}
+
 // Load Transfer Account List Saga
-function* loadTransferAccounts({ payload }) {
+function* loadTransferAccounts({ payload }: TransferAccountLoadApiResult) {
   try {
     const load_result = yield call(loadTransferAccountListAPI, payload);
 
@@ -83,8 +101,13 @@ function* watchLoadTransferAccounts() {
   yield takeEvery(LOAD_TRANSFER_ACCOUNTS_REQUEST, loadTransferAccounts);
 }
 
+interface TransferAccountEditApiResult {
+  type: typeof EDIT_TRANSFER_ACCOUNT_REQUEST;
+  payload: any;
+}
+
 // Edit Transfer Account Saga
-function* editTransferAccount({ payload }) {
+function* editTransferAccount({ payload }: TransferAccountEditApiResult) {
   try {
     const edit_response = yield call(editTransferAccountAPI, payload);
 


### PR DESCRIPTION
**Describe the Pull Request**
converts the `creditTransfer` reducer to typescript following the format of the `messages` reducer, and adds a couple specs

**Q:**
~~I saw references to `PUSHER_*` actions that look unused ... are those deprecated now?~~