### PR TITLE
CI: limit docker services to ones relevant to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Run Docker Tests
           command: |
             export GIT_HASH=$CIRCLE_SHA1
-            docker-compose up --exit-code-from app
+            docker-compose up app --exit-code-from app
   test:worker:
     working_directory: ~/project
     docker:
@@ -104,7 +104,7 @@ jobs:
           name: Run Docker Tests
           command: |
             export GIT_HASH=$CIRCLE_SHA1
-            docker-compose up --exit-code-from eth_worker
+            docker-compose up eth_worker --exit-code-from eth_worker
   test:frontend:
     working_directory: ~/project
     docker:


### PR DESCRIPTION
**Describe the Pull Request**

This is a small optimization: When running tests in CircleCI with docker, this scopes the services that are started to the ones in which tests are running (assuming all container dependencies are specified)