### PR TITLE
Add time-series metrics

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.1.42'  # Remember to bump this in every PR
+VERSION = '1.1.43'  # Remember to bump this in every PR
 
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))


### PR DESCRIPTION
Add new time-series metrics to metrics endpoint. We want to be able to get average number of trades per user, and average dollar amount of trades per user. We should also be able to get daily active users, and users created. All of these should be able to be fetched on a daily, weekly, or monthly level