### PR TITLE
Use a bootstrap entrypoint task to migrate database

### DIFF
--- a/app/_docker_app_script.sh
+++ b/app/_docker_app_script.sh
@@ -2,9 +2,6 @@
 echo Container mode: $CONTAINER_MODE
 
 cd src
-echo upgrading database
-python manage.py db upgrade
-
 ret=$?
 if [ "$ret" -ne 0 ]; then
   exit $ret
@@ -27,12 +24,12 @@ if [ "$CONTAINER_MODE" == 'TEST' ]; then
 elif [ "$CONTAINER_MODE" == 'ETH_WORKER_TEST' ]; then
    echo pass
    sleep infinity
-else
-
-  echo upgrading dataset
-
+elif [ "$CONTAINER_MODE" == 'BOOTSTRAP' ]; then
+  echo upgrading database
+  echo bootstrapping dataset
+  python manage.py db upgrade
   python manage.py update_data
-
+else
   uwsgi --socket 0.0.0.0:9000 --protocol http  --processes 4 --enable-threads --module=server.wsgi:app --stats :3031 --stats-http
 fi
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,11 +2,19 @@
 
 version: "3"
 services:
+  bootstrap:
+    image: "server:${IMAGE_TAG:-latest}"
+    environment:
+      DEPLOYMENT_NAME: "LOCAL_DOCKER"
+      CONTAINER_TYPE: "APP"
+      CONTAINER_MODE: "BOOTSTRAP" # sets up sample data
+    depends_on:
+      - postgres
   app:
     environment:
       DEPLOYMENT_NAME: "LOCAL_DOCKER"
       CONTAINER_TYPE: "APP"
-      CONTAINER_MODE: "" # sets up sample data
+      CONTAINER_MODE: ""
   eth_worker:
     environment:
       DEPLOYMENT_NAME: "LOCAL_DOCKER"


### PR DESCRIPTION
**Describe the Pull Request**

Putting this up for discussion. Currently the app docker container applies the migrations to the database each time an app container is started, which, while idempotent isn't strictly necessary, and slows container startup. When the server process is started, it also applies the update_data command (which I also believe is idempotent)

This was causing some problems in my local docker dev environment and decoupling the data migration/creation from app startup seems to make things go smoother.

With this update, the app service generally starts with a single command - it may be more direct/conventional to specify the command in the docker-compose and the AWS EBS config https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/single-container-docker-configuration.html but honestly the current shell script works fine and once I saw what it was doing it makes sense
**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [ ] Request review from relevant @person or team
- [ ] QA your pull request. This includes running the app, login, testing changes etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
