### PR TITLE
Swapping Eventlet for Gevent in eth workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Transaction on the blockchain are made using asynchronous workers that consume a
 
 ```
 cd eth_worker
-celery -A eth_manager worker --loglevel=INFO --concurrency=8 --pool=eventlet -Q processor,celery,low-priority,high-priority
+celery -A eth_manager worker --loglevel=INFO --concurrency=8 --pool=gevent -Q processor,celery,low-priority,high-priority
 ```
 
 ## Details and Other Options
@@ -156,7 +156,7 @@ Start celery:
 
 ```
 cd eth_worker
-celery -A eth_manager worker --loglevel=INFO --concurrency=8 --pool=eventlet -Q processor,celery,low-priority,high-priority
+celery -A eth_manager worker --loglevel=INFO --concurrency=8 --pool=gevent -Q processor,celery,low-priority,high-priority
 ```
 
 You can also add a runtime configuration with the `script path` set as the path to your virtual env `[path-to-your-python-env]/bin/celery`.

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.2.7'  # Remember to bump this in every PR
+VERSION = '1.2.8'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 

--- a/eth_worker/_docker_worker_script.sh
+++ b/eth_worker/_docker_worker_script.sh
@@ -37,17 +37,17 @@ else
         flower -A worker --port=5555
     elif [ "$CONTAINER_TYPE" == 'PROCESSOR' ]; then
         echo "Starting Processor Worker"
-        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=eventlet -Q=processor --without-gossip --without-mingle
+        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=gevent -Q=processor --without-gossip --without-mingle
     elif [ "$CONTAINER_TYPE" == 'LOW_PRIORITY_WORKER' ]; then
         echo "Starting Low Priority Worker"
-        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=eventlet -Q=low-priority,celery --without-gossip --without-mingle
+        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=gevent -Q=low-priority,celery --without-gossip --without-mingle
     elif [ "$CONTAINER_TYPE" == 'HIGH_PRIORITY_WORKER' ]; then
         echo "Starting High Priority Worker"
         alembic upgrade head
-        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=eventlet -Q=high-priority --without-gossip --without-mingle
+        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=gevent -Q=high-priority --without-gossip --without-mingle
     elif [ "$CONTAINER_TYPE" == 'ANY_PRIORITY_WORKER' ]; then
         echo "Starting Any Priority Worker"
-        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=eventlet -Q=low-priority,celery,high-priority,processor --without-gossip --without-mingle
+        celery -A eth_manager worker --loglevel=INFO --concurrency=$WORKER_CONCURRENCY --pool=gevent -Q=low-priority,celery,high-priority,processor --without-gossip --without-mingle
     else
 #       Default to primary worker configuration - running alembic upgrade twice is fine.
         echo "Running alembic upgrade (Default)"
@@ -57,6 +57,6 @@ else
             exit $ret
         fi
         echo "Starting Generic Worker (Default)"
-        celery -A eth_manager worker --loglevel=INFO --concurrency=10 --pool=eventlet -Q=low-priority,celery,high-priority --without-gossip --without-mingle
+        celery -A eth_manager worker --loglevel=INFO --concurrency=10 --pool=gevent -Q=low-priority,celery,high-priority --without-gossip --without-mingle
     fi
 fi

--- a/eth_worker/requirements.txt
+++ b/eth_worker/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.1.0
 boto3==1.7.33
 cryptography==2.3
 celery==4.4.0rc3
-eventlet==0.24.1
+gevent==20.6.2
 flower==0.9.3
 kombu==4.6.6
 idna==2.6

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -20,12 +20,12 @@ WORKDIR /
 
 EXPOSE 80
 
-#ENTRYPOINT celery -A worker worker --loglevel=INFO --concurrency=500 --pool=eventlet
-#CMD ["celery -A worker worker --loglevel=INFO --concurrency=500 --pool=eventlet"]
+#ENTRYPOINT celery -A worker worker --loglevel=INFO --concurrency=500 --pool=gevent
+#CMD ["celery -A worker worker --loglevel=INFO --concurrency=500 --pool=gevent"]
 
 RUN chmod +x /_docker_worker_script.sh
 RUN chmod +x /_beat_starter.sh
 
 CMD ["/_docker_worker_script.sh"]
 
-#ENTRYPOINT celery -A worker worker --loglevel=INFO --concurrency=500 --pool=eventlet
+#ENTRYPOINT celery -A worker worker --loglevel=INFO --concurrency=500 --pool=gevent

--- a/worker/_beat_starter.sh
+++ b/worker/_beat_starter.sh
@@ -4,4 +4,4 @@
 
 celery -A worker beat --loglevel=WARNING
 
-#-A worker worker --loglevel=INFO --concurrency=500 --pool=eventlet
+#-A worker worker --loglevel=INFO --concurrency=500 --pool=gevent


### PR DESCRIPTION
**Describe the Pull Request**

Eventlet is causing failures in our CI pipeline, that Gevent doesn't seem to cause. In lieu of having a strong opinion about using greenthreads or not, swapping to the more popular library that doesn't break seems like the wise move!

**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [ ] Request review from relevant @person or team
- [ ] QA your pull request. This includes running the app, login, testing changes etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
