### PR TITLE
Remove Dashboard Auth Race Condition

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "SempoBlockchain",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SempoBlockchain",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "Sempo blockchain web app using Python-Flask and React",
   "main": "index.js",
   "homepage": "./",


### PR DESCRIPTION
**Describe the Pull Request**

After logging into the dashboard, it's possible to have a race condition where the session token is accessed by another call before it's stored, which logs the system out. 

The make the session token storage synchronous, preventing said condition

**Todo**

- ~~[ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request~~
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
