### PR TITLE
Make user overridable

### DIFF
--- a/app/server/models/organisation.py
+++ b/app/server/models/organisation.py
@@ -45,7 +45,9 @@ class Organisation(ModelBase):
     users               = db.relationship(
         "User",
         secondary=organisation_association_table,
-        back_populates="organisations")
+        back_populates="organisations",
+        enable_typechecks=False,
+        )
 
     token_id            = db.Column(db.Integer, db.ForeignKey('token.id'))
 

--- a/app/server/models/user.py
+++ b/app/server/models/user.py
@@ -68,6 +68,10 @@ class User(ManyOrgBase, ModelBase, SoftDelete):
     """
     __tablename__ = 'user'
 
+    __mapper_args = {
+        'polymorphic_identity': 'user',
+            }
+
     first_name = db.Column(db.String())
     last_name = db.Column(db.String())
     preferred_language = db.Column(db.String())


### PR DESCRIPTION
We maintain some diff patches against your code locally to work around elements that aren't modular or extensible. Doing so creates overhead for merges, and also potentially a source of bugs when we don't cherry-pick the changes properly.

This is one example of such.

Grassroots Economics need to extend the user model. I am not sure if this is the best way to do it, but without these changes so far I have not been able to use our ExtendedUser (which just extends the User class) with User intechangeably where User is the type. I believe sqlalchemy or flask or both does some strict type checking to prevent it.

If this change introduces security concerns for you (after all, it skips some checks that otherwise would protect code integrity) I would like find a different way to do it, and would like to hear your proposals. Thanks.
