### PR TITLE
Chart tooltip mode

### DIFF
--- a/app/client/components/dashboard/card/VolumeChart.jsx
+++ b/app/client/components/dashboard/card/VolumeChart.jsx
@@ -109,7 +109,7 @@ class VolumeChart extends React.Component {
         display: false
       },
       tooltips: {
-        mode: "nearest",
+        mode: "x",
         backgroundColor: "rgba(87, 97, 113, 0.9)",
         cornerRadius: 1
       },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "SempoBlockchain",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SempoBlockchain",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Sempo blockchain web app using Python-Flask and React",
   "main": "index.js",
   "homepage": "./",


### PR DESCRIPTION
**Describe the Pull Request**
Very small fix that changes volume chart tooltip mode to be `x` instead of `nearest`. This is more inline with the initial mockups created and is useful for seeing data for all grouped types on the given timeseries point.

<img width="1116" alt="Screen Shot 2020-08-19 at 8 44 04 pm" src="https://user-images.githubusercontent.com/27039316/90625416-e11f1280-e25c-11ea-82e4-63a0ae3aedcb.png">

**Todo**

- ~~[ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request~~
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
