### PR TITLE
Only get bound transfer cards

### DIFF
--- a/app/server/api/transfer_card_api.py
+++ b/app/server/api/transfer_card_api.py
@@ -14,14 +14,15 @@ class TransferCardAPI(MethodView):
     def get(self):
         """
         Get a list of the transfer cards on the system.
-        :arg only_loaded: only return cards that have funds loaded onto them. Prevents returning a list of 100000 cards. Defaults true.
+        :arg only_bound: only return cards that have transfer accounts bound to them.
+        Prevents returning a list of 100000 cards and overwhelming low power android phones. Defaults true.
         :return:
         """
 
-        only_loaded = request.args.get('only_loaded', 'true').lower() == 'true' #defaults true
+        only_bound = request.args.get('only_bound', 'true').lower() == 'true' #defaults true
 
-        if only_loaded:
-            transfer_cards = TransferCard.query.filter(TransferCard.amount_loaded_signature != None).all()
+        if only_bound:
+            transfer_cards = TransferCard.query.filter(TransferCard.transfer_account_id != None).all()
         else:
             transfer_cards = TransferCard.query.all()
 
@@ -46,8 +47,9 @@ class TransferCardAPI(MethodView):
 
             return make_response(jsonify(response_object)), 400
 
-        public_serial_number = re.sub(r'[\t\n\r]', '', public_serial_number)
-
+        # serial numbers are case insensitive
+        public_serial_number = re.sub(r'[\t\n\r]', '', str(public_serial_number)).upper()
+        nfc_serial_number = nfc_serial_number.upper()
 
         if TransferCard.query.filter_by(public_serial_number=public_serial_number).first():
             response_object = {

--- a/app/server/api/transfer_card_api.py
+++ b/app/server/api/transfer_card_api.py
@@ -12,8 +12,18 @@ transfer_cards_blueprint = Blueprint('transfer_cards', __name__)
 class TransferCardAPI(MethodView):
     @requires_auth
     def get(self):
+        """
+        Get a list of the transfer cards on the system.
+        :arg only_loaded: only return cards that have funds loaded onto them. Prevents returning a list of 100000 cards. Defaults true.
+        :return:
+        """
 
-        transfer_cards = TransferCard.query.all()
+        only_loaded = request.args.get('only_loaded', 'true').lower() == 'true' #defaults true
+
+        if only_loaded:
+            transfer_cards = TransferCard.query.filter(TransferCard.amount_loaded_signature != None).all()
+        else:
+            transfer_cards = TransferCard.query.all()
 
         response_object = {
             'message': 'Successfully loaded transfer_cards',

--- a/app/test_app/functional/test_transfer_card_api.py
+++ b/app/test_app/functional/test_transfer_card_api.py
@@ -1,36 +1,36 @@
 from server.models.transfer_card import TransferCard
-import json, pytest
+import json
 
-def test_transfer_card_api(test_client, init_database, complete_admin_auth_token):
+def test_transfer_card_api(test_client, init_database, complete_admin_auth_token, create_transfer_account_user):
 
     # Test regular load of card
     response = test_client.post('/api/v1/transfer_cards/',
                                 headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
                                 data=json.dumps({
-                                    'public_serial_number': '123456',
-                                    'nfc_serial_number': 'abcd1234f'
+                                    'public_serial_number': 123456,
+                                    'nfc_serial_number': 'ABCD1234F'
                                 }),
                                 content_type='application/json', follow_redirects=True)
 
     assert response.status_code == 201
 
-    # Ensure duplicated public_serial_number fails
+    # Ensure duplicated public_serial_number fails, even if provided as string
     response = test_client.post('/api/v1/transfer_cards/',
                                 headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
                                 data=json.dumps({
                                     'public_serial_number': '123456',
-                                    'nfc_serial_number': '123deef'
+                                    'nfc_serial_number': '123DEEF'
                                 }),
                                 content_type='application/json', follow_redirects=True)
 
     assert response.status_code == 400
 
-    # Ensure duplicated nfc_id fails
+    # Ensure duplicated nfc_id fails, even if nfc is lowercase
     response = test_client.post('/api/v1/transfer_cards/',
                                 headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
                                 data=json.dumps({
                                     'public_serial_number': '22222',
-                                    'nfc_serial_number': 'abcd1234f'
+                                    'nfc_serial_number': 'abcd1234F'
                                 }),
                                 content_type='application/json', follow_redirects=True)
 
@@ -42,23 +42,52 @@ def test_transfer_card_api(test_client, init_database, complete_admin_auth_token
     assert len(cards) == 1
     card = cards[0]
     assert card.public_serial_number == '123456'
-    assert card.nfc_serial_number == 'abcd1234f'
+    assert card.nfc_serial_number == 'ABCD1234F'
 
     # Now try a get of the data
-
-    response = test_client.get('/api/v1/transfer_usage/',
-                               args=
+    response = test_client.get('/api/v1/transfer_cards/',
                                headers=dict(
                                    Authorization=complete_admin_auth_token, Accept='application/json'),
                                follow_redirects=True)
 
     assert response.status_code == 200
-    assert isinstance(response.json['data']['transfer_usages'], list)
+    # Should not return any cards, since defaults to not returning cards bound to a transfer_account
+    assert len(response.json['data']['transfer_cards']) == 0
 
-    # Ensure that the posting a duplicate transfer ussage results in a 400
-    response = test_client.post('/api/v1/transfer_usage/',
-                                headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
-                                data=json.dumps(dict(name=name, icon=icon, translations=translations)),
-                                content_type='application/json', follow_redirects=True)
+    # Now try a get of the data, getting ALL cards, not just ones that are bound
+    response = test_client.get('/api/v1/transfer_cards/?only_bound=false',
+                               headers=dict(
+                                   Authorization=complete_admin_auth_token, Accept='application/json'),
+                               follow_redirects=True)
 
-    assert response.status_code == 400
+    assert response.status_code == 200
+
+    card_json = response.json['data']['transfer_cards'][0]
+    assert card_json['nfc_serial_number'] == 'ABCD1234F'
+    assert card_json['public_serial_number'] == '123456'
+
+    # Now bind to a user
+    test_client.put(
+        f"/api/v1/user/{create_transfer_account_user.id}/",
+        headers=dict(
+            Authorization=complete_admin_auth_token,
+            Accept='application/json'
+        ),
+        json={
+            'public_serial_number': '123456'
+    })
+
+    response = test_client.get('/api/v1/transfer_cards/',
+                               headers=dict(
+                                   Authorization=complete_admin_auth_token, Accept='application/json'),
+                               follow_redirects=True)
+
+    assert response.status_code == 200
+
+    # Should now return our card
+    card_json = response.json['data']['transfer_cards'][0]
+    assert card_json['nfc_serial_number'] == 'ABCD1234F'
+    assert card_json['public_serial_number'] == '123456'
+
+
+

--- a/app/test_app/functional/test_transfer_card_api.py
+++ b/app/test_app/functional/test_transfer_card_api.py
@@ -1,0 +1,64 @@
+from server.models.transfer_card import TransferCard
+import json, pytest
+
+def test_transfer_card_api(test_client, init_database, complete_admin_auth_token):
+
+    # Test regular load of card
+    response = test_client.post('/api/v1/transfer_cards/',
+                                headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
+                                data=json.dumps({
+                                    'public_serial_number': '123456',
+                                    'nfc_serial_number': 'abcd1234f'
+                                }),
+                                content_type='application/json', follow_redirects=True)
+
+    assert response.status_code == 201
+
+    # Ensure duplicated public_serial_number fails
+    response = test_client.post('/api/v1/transfer_cards/',
+                                headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
+                                data=json.dumps({
+                                    'public_serial_number': '123456',
+                                    'nfc_serial_number': '123deef'
+                                }),
+                                content_type='application/json', follow_redirects=True)
+
+    assert response.status_code == 400
+
+    # Ensure duplicated nfc_id fails
+    response = test_client.post('/api/v1/transfer_cards/',
+                                headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
+                                data=json.dumps({
+                                    'public_serial_number': '22222',
+                                    'nfc_serial_number': 'abcd1234f'
+                                }),
+                                content_type='application/json', follow_redirects=True)
+
+    assert response.status_code == 400
+
+    # Make sure db reflects what we'd expect
+    cards = TransferCard.query.all()
+
+    assert len(cards) == 1
+    card = cards[0]
+    assert card.public_serial_number == '123456'
+    assert card.nfc_serial_number == 'abcd1234f'
+
+    # Now try a get of the data
+
+    response = test_client.get('/api/v1/transfer_usage/',
+                               args=
+                               headers=dict(
+                                   Authorization=complete_admin_auth_token, Accept='application/json'),
+                               follow_redirects=True)
+
+    assert response.status_code == 200
+    assert isinstance(response.json['data']['transfer_usages'], list)
+
+    # Ensure that the posting a duplicate transfer ussage results in a 400
+    response = test_client.post('/api/v1/transfer_usage/',
+                                headers=dict(Authorization=complete_admin_auth_token, Accept='application/json'),
+                                data=json.dumps(dict(name=name, icon=icon, translations=translations)),
+                                content_type='application/json', follow_redirects=True)
+
+    assert response.status_code == 400

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.6.10'  # Remember to bump this in every PR
+VERSION = '1.6.11'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**

A short modification to the transfer card get request that ensures that only cards that are actually bound to users are returned. Will be replaced by a full sharding solution shortly.

Also includs tests for the transfer card api

**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [ ] Request review from relevant @person or team
- [ ] QA your pull request. This includes running the app, login, testing changes etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
