### PR TITLE
Don't overwrite transfer usages during dataset upgrade if usages already exist

### DIFF
--- a/app/migrations/seed.py
+++ b/app/migrations/seed.py
@@ -272,7 +272,13 @@ def create_ussd_menus():
     print_section_conclusion('Done creating USSD Menus')
 
 
-def create_business_categories():
+def create_business_categories(only_if_none_exist=True):
+
+    if only_if_none_exist:
+        usages = db.session.query(TransferUsage).all()
+        if len(usages) > 0:
+            print("Business Categories already exist! Skipping.")
+            return
 
     print_section_title('Creating Business Categories')
     business_categories = [

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.6.10'  # Remember to bump this in every PR
+VERSION = '1.6.11'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**

Currently, when the update_date migration is run on instance boot, specified transfer usages are liable overwritten by the default usages provided in the seed script. This PR prevents the default usages from being added unless no transfer usages  currently exist.

**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [ ] Request review from relevant @person or team
- [ ] QA your pull request. This includes running the app, login, testing changes etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
