### PR TITLE
Increase CI/CD job resource class to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/python:3.6-node
         environment:
           CONTAINER_MODE: TEST
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:
@@ -78,6 +79,7 @@ jobs:
       - image: circleci/python:3.6-node
         environment:
           CONTAINER_MODE: TEST
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
**Describe the Pull Request**
Increasing Circle's `resource_class` to large on our build and backend testing steps should increase performance. Both steps are the longest testing process of our CI/CD. [example](https://app.circleci.com/pipelines/github/teamsempo/SempoBlockchain/3504/workflows/fa533a0a-6648-4cd1-b55a-2c872f32377a)

<img width="671" alt="Screen Shot 2020-10-09 at 2 01 55 pm" src="https://user-images.githubusercontent.com/27039316/95537004-334c0b00-0a38-11eb-9701-f2b44081f1dd.png">

**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [ ] Request review from relevant @person or team
- [ ] QA your pull request. This includes running the app, login, testing changes etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
