### PR TITLE
Configurable option on data wrapper

### DIFF
--- a/app/server/utils/attribute_preprocessor.py
+++ b/app/server/utils/attribute_preprocessor.py
@@ -29,12 +29,18 @@ def unwrap_data(attribute_dict):
     """
     Allows the use of wrapped data payloads by taking the contents of _data and moving it up a level.
     This is useful for setting default values in the wrapper in tools such as Kobo toolbox.
-    In the event of a conflict between two levels, the wrapped data takes priority.
+    In the event of a conflict between two levels, the _wrapped_takes_priority field
+    (defined in the wrapper) sets data takes priority and overwrites the other.
     {'is_vendor': True, '_data': {'first_name': 'Alice'}} -> {'is_vendor': True, 'first_name': 'Alice'}
     """
     _data = attribute_dict.get('_data')
+    _wrapped_takes_priority = attribute_dict.get('_wrapped_takes_priority', True)
     if isinstance(_data, dict):
-        attribute_dict = {**attribute_dict, **_data}
+        if _wrapped_takes_priority:
+            attribute_dict = {**attribute_dict, **_data}
+        else:
+            attribute_dict = {**_data, **attribute_dict}
+
         attribute_dict.pop('_data')
 
     return attribute_dict

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.6.30'  # Remember to bump this in every PR
+VERSION = '1.6.31'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**

Option in data pre-processor to set whether wrapped data overwrites wrap data or vice-versa
**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [ ] Request review from relevant @person or team
- [ ] QA your pull request. This includes running the app, login, testing changes etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
