### PR TITLE
Make SynchronizedBlock be updated in batch instead of one giant update

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.7.27'  # Remember to bump this in every PR
+VERSION = '1.7.28'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 

--- a/eth_worker/eth_src/sql_persistence/interface.py
+++ b/eth_worker/eth_src/sql_persistence/interface.py
@@ -535,10 +535,9 @@ class SQLPersistenceInterface(object):
         self.session.commit()
 
     def set_block_range_status(self, start, end, status, filter_id):
-        for n in range(start, end):
-            blocks  = self.session.query(SynchronizedBlock).filter(SynchronizedBlock.block_number == n, SynchronizedBlock.synchronization_filter_id == filter_id).all()
-            for block in blocks:
-                block.status = status
+        blocks  = self.session.query(SynchronizedBlock)\
+            .filter(SynchronizedBlock.block_number >= start, SynchronizedBlock.block_number < end, SynchronizedBlock.synchronization_filter_id == filter_id)\
+            .update({'status': status})
         self.session.commit()
 
 

--- a/eth_worker/test_eth_worker/unit/test_third_party_sync.py
+++ b/eth_worker/test_eth_worker/unit/test_third_party_sync.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sql_persistence.interface import SQLPersistenceInterface
-from sql_persistence.models import BlockchainTransaction
+from sql_persistence.models import BlockchainTransaction, SynchronizedBlock
 from eth_manager.blockchain_sync import blockchain_sync_constants
 
 class TestModels:
@@ -71,7 +71,7 @@ class TestModels:
         assert f.max_block == expected_max_block
 
     # Tests get_blockchain_history
-    def test_get_blockchain_transaction_history(self, mocker, blockchain_sync, processor):
+    def test_get_blockchain_transaction_history(self, mocker, blockchain_sync, processor, db_session):
         # Need a valid filter object since get_blockchain_transaction_history creates and modifies 
         # the SynchronizedBlock table, which has needs to be linked to a tx filter foreign key
         filter = blockchain_sync.add_transaction_filter(
@@ -109,6 +109,11 @@ class TestModels:
             # Have to consume generator for test to halt
             assert event == None
 
+        blocks = db_session.query(SynchronizedBlock).all()
+        for b in blocks:
+            assert b.status == 'SUCCESS'
+        assert len(blocks) == 500
+        
     def test_synchronize_third_party_transactions(
             self, mocker, blockchain_sync, processor, persistence_module: SQLPersistenceInterface
     ):


### PR DESCRIPTION
**Describe the Pull Request**

We were doing stupidly many UPDATEs  for each `SynchronizedBlock`, and that was using an alarming amount of database capacity. This does one big, clean batch-UPDATE. 

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
