### PR TITLE
Only update BlockchainTransaction on the worker when we absolutely have to

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.7.28'  # Remember to bump this in every PR
+VERSION = '1.7.29'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.7.27'  # Remember to bump this in every PR
+VERSION = '1.7.28'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 

--- a/eth_worker/eth_src/sql_persistence/interface.py
+++ b/eth_worker/eth_src/sql_persistence/interface.py
@@ -144,12 +144,11 @@ class SQLPersistenceInterface(object):
         return calculated_nonce
 
     def update_transaction_data(self, transaction_id, transaction_data):
-
         transaction = self.session.query(BlockchainTransaction).get(transaction_id)
 
         for attribute in transaction_data:
-            setattr(transaction, attribute, transaction_data[attribute])
-
+            if transaction_data[attribute] != getattr(transaction, attribute):
+                setattr(transaction, attribute, transaction_data[attribute])
         self.session.commit()
 
     def create_blockchain_transaction(self, task_uuid):


### PR DESCRIPTION
**Describe the Pull Request**

Whenever we update `BlockchainTransaction`, the `/api/v1/blockchain_taskable` webhook is called. The problem is that we update `BlockchainTransaction` when we don't have to a lot of the time (like when the state changes from `PENDING` to `PENDING`), leading to a bunch of webhook calls that don't ever really have to happen. This tests to make sure that we _need_ to update, before we actually do!     

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
