### PR TITLE
Add endpoint to flush metrics cache

### DIFF
--- a/app/server/api/metrics_api.py
+++ b/app/server/api/metrics_api.py
@@ -131,7 +131,7 @@ class FiltersApi(MethodView):
         return make_response(jsonify(response_object)), 200
 
 class CacheApi(MethodView):
-    @requires_auth(allowed_roles={'ADMIN': 'any'})
+    @requires_auth(allowed_roles={'ADMIN': 'sempoadmin'})
     def post(self):
         """
         This endpoint erases the cache for the current org. 

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.7.54'  # Remember to bump this in every PR
+VERSION = '1.7.56'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**

Sometimes if we change the past, the cache gets invalidated and we get some strange behaviour. This adds an endpoint to nuke the cache for a given org if we have to

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
