### PR TITLE
refactor: rename organisation to project

### DIFF
--- a/app/client/components/navBar/OrgSwitcher.tsx
+++ b/app/client/components/navBar/OrgSwitcher.tsx
@@ -70,7 +70,7 @@ const OrgSwitcher: React.FunctionComponent<Props> = props => {
       }}
       selectedKeys={[activeOrganisation && activeOrganisation.id.toString()]}
     >
-      <Menu.ItemGroup title="Your Organisations">
+      <Menu.ItemGroup title="Your Projects">
         {orgs.map((org: Organisation) => {
           return (
             <Menu.Item key={org.id} onClick={() => selectOrg(org.id)}>
@@ -84,8 +84,8 @@ const OrgSwitcher: React.FunctionComponent<Props> = props => {
         <IntercomChat />
       </Menu.Item>
       <Menu.Item key="new">
-        <NavLink to="/settings/organisation/new">
-          <FolderAddOutlined translate={""} /> New Organisation
+        <NavLink to="/settings/project/new">
+          <FolderAddOutlined translate={""} /> New Project
         </NavLink>
       </Menu.Item>
       <Menu.Item key="invite">

--- a/app/client/components/organisation/OrganisationForm.tsx
+++ b/app/client/components/organisation/OrganisationForm.tsx
@@ -89,9 +89,9 @@ const NewOrganisationForm = (props: OuterProps) => {
       }
     >
       <Form.Item
-        tooltip="The name of your organisation or project"
+        tooltip="The name of your project"
         name="organisationName"
-        label="Organisation Name"
+        label="Project Name"
         required={isNewOrg}
         rules={[
           {
@@ -103,7 +103,7 @@ const NewOrganisationForm = (props: OuterProps) => {
       </Form.Item>
 
       <Form.Item
-        tooltip="Select a token to use for this organisation"
+        tooltip="Select a token to use for this project"
         name="token"
         label="Token"
         required={isNewOrg}
@@ -150,7 +150,7 @@ const NewOrganisationForm = (props: OuterProps) => {
       <TokenModalForm visible={visible} onCancel={() => setVisible(false)} />
 
       <Form.Item
-        tooltip="The default country code for this organisation. Used for phone numbers."
+        tooltip="The default country code for this project. Used for phone numbers."
         name="countryCode"
         label="Default Country Code"
         required={isNewOrg}
@@ -179,7 +179,7 @@ const NewOrganisationForm = (props: OuterProps) => {
       </Form.Item>
 
       <Form.Item
-        tooltip="The default time zone for this organisation."
+        tooltip="The default time zone for this project."
         name="timezone"
         label="Default Time Zone"
         required={isNewOrg}
@@ -208,7 +208,7 @@ const NewOrganisationForm = (props: OuterProps) => {
       </Form.Item>
 
       <Form.Item
-        tooltip="The available account types for this organisation."
+        tooltip="The available account types for this project."
         name="accountTypes"
         label="Account Types"
       >
@@ -232,7 +232,7 @@ const NewOrganisationForm = (props: OuterProps) => {
       </Form.Item>
 
       <Form.Item
-        tooltip="The default disbursement amount for new beneficiaries created in this organisation"
+        tooltip="The default disbursement amount for new beneficiaries created in this project"
         name="defaultDisbursement"
         label="Default Disbursement"
       >
@@ -240,7 +240,7 @@ const NewOrganisationForm = (props: OuterProps) => {
       </Form.Item>
 
       <Form.Item
-        tooltip="The minimum vendor payout withdrawal amount for this organisation"
+        tooltip="The minimum vendor payout withdrawal amount for this project"
         name="minimumVendorPayoutWithdrawal"
         label="Minimum Vendor Payout Withdrawal"
       >
@@ -248,7 +248,7 @@ const NewOrganisationForm = (props: OuterProps) => {
       </Form.Item>
 
       <Form.Item
-        tooltip="The distance to automatically load transfer cards onto vendor phones for this organisation"
+        tooltip="The distance to automatically load transfer cards onto vendor phones for this project"
         name="cardShardDistance"
         label="Automatically Load Cards Within"
       >

--- a/app/client/components/pages/settings/OrganisationPage.tsx
+++ b/app/client/components/pages/settings/OrganisationPage.tsx
@@ -126,7 +126,7 @@ class OrganisationPage extends React.Component<IProps, IState> {
     return (
       <Space direction="vertical" style={{ width: "100%" }} size="middle">
         <Card
-          title={isNewOrg ? "New Organisation" : "Edit Organisation"}
+          title={isNewOrg ? "New Project" : "Edit Project"}
           bodyStyle={{ maxWidth: "400px" }}
         >
           {this.state.isoCountries ? (

--- a/app/client/components/pages/settings/settingsPage.jsx
+++ b/app/client/components/pages/settings/settingsPage.jsx
@@ -26,11 +26,8 @@ export default class settingsPage extends React.Component {
               <p style={{ margin: "1em" }}></p>
               <ExternalAuthCredentials />
               <GetVerified />
-              <PageLink
-                to="/settings/organisation"
-                headerText="Organisation Settings"
-              >
-                Update your organisation settings
+              <PageLink to="/settings/project" headerText="Project Settings">
+                Update your project settings
               </PageLink>
             </RestrictedModuleBox>
 

--- a/app/client/nav.jsx
+++ b/app/client/nav.jsx
@@ -180,20 +180,20 @@ class Nav extends React.Component {
             />
             <PrivateRoute
               exact
-              path="/settings/organisation"
+              path="/settings/project"
               component={OrganisationPage}
               isLoggedIn={isLoggedIn}
               isReAuthing={isReAuthing}
-              title={`Organisation Settings`}
+              title={`Project Settings`}
               isAntDesign={true}
             />
             <PrivateRoute
               exact
-              path="/settings/organisation/new"
+              path="/settings/project/new"
               component={OrganisationPage}
               isLoggedIn={isLoggedIn}
               isReAuthing={isReAuthing}
-              title={`New Organisation`}
+              title={`New Project`}
               isAntDesign={true}
               isNewOrg={true}
             />

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SempoBlockchain",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Sempo blockchain web app using Python-Flask and React",
   "main": "index.js",
   "homepage": "./",

--- a/postman/SempoBlockchain.postman_collection.json
+++ b/postman/SempoBlockchain.postman_collection.json
@@ -1410,7 +1410,7 @@
           ]
         },
         {
-          "name": "Get Organisation",
+          "name": "Get Organisation (Project)",
           "request": {
             "method": "GET",
             "header": [

--- a/postman/SempoBlockchain.postman_collection.json
+++ b/postman/SempoBlockchain.postman_collection.json
@@ -1114,10 +1114,10 @@
       "description": "The AUTH API is primarily used for user login, logout, password actions. This is used for both Admin and standard platform users.\n\nThere is also a sub-folder \"permissions\" that is used for managing admin user tiers and platform admin invites."
     },
     {
-      "name": "Organisation API",
+      "name": "Organisation (Project) API",
       "item": [
         {
-          "name": "Create Organisation",
+          "name": "Create Organisation (Project)",
           "request": {
             "method": "POST",
             "header": [
@@ -1239,7 +1239,7 @@
           ]
         },
         {
-          "name": "Edit Organisation",
+          "name": "Edit Organisation (Project)",
           "request": {
             "method": "PUT",
             "header": [


### PR DESCRIPTION
**Describe the Pull Request**
Renames `Organisation` to `Project` on the frontend. Lightweight refactor of only the frontend names exposed to user. Component Names, redux state, backend API etc. are still called organisations. This causes some issues with the API errors returning "Organisation" but it's limited. I don't think a further refactor is worth it unless it's the whole codebase (which would be a breaking change v2.0.0). 

<img width="1792" alt="Screen Shot 2021-02-17 at 3 22 14 pm" src="https://user-images.githubusercontent.com/27039316/108156130-39639e00-7134-11eb-9dcc-50e7457b7942.png">

<img width="391" alt="Screen Shot 2021-02-17 at 3 28 34 pm" src="https://user-images.githubusercontent.com/27039316/108156478-d7576880-7134-11eb-8f3d-57635c5c2cf1.png">


**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
