### PR TITLE
Stabilize metrics tests

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -16,6 +16,7 @@ Flask-Migrate==2.5.3
 Flask-RESTful==0.3.6
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.4
+freezegun==1.1.0
 kombu==4.6.11
 toastedmarshmallow==2.15.2.post1
 messagebird==1.5.0

--- a/app/test_app/functional/api/test_metrics_api.py
+++ b/app/test_app/functional/api/test_metrics_api.py
@@ -1,4 +1,5 @@
 import pytest
+from freezegun import freeze_time
 from server.models.transfer_usage import TransferUsage
 from server.models.custom_attribute import CustomAttribute, MetricsVisibility
 from server.utils.transfer_filter import Filters
@@ -10,6 +11,7 @@ import os
 from datetime import datetime, timedelta
 from dateutil.parser import isoparse
 
+@freeze_time("2020-02-15 13:30:00")
 @pytest.fixture(scope='module')
 def generate_timeseries_metrics(create_organisation):
     # Truncates date for timezone comparison to work any time of day you run the tests!

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ pytest==6.0.0
 coverage==5.2.1
 pytest-mock==3.2.0
 factory_boy==2.12.0
+freezegun==1.1.0


### PR DESCRIPTION
**Describe the Pull Request**

Freezes time at dummy-data creation time to make sure the tests don't blow up at any time of the day  

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
