### PR TITLE
fix: intercom unique id bug

### DIFF
--- a/app/client/components/intercom/IntercomSetup.tsx
+++ b/app/client/components/intercom/IntercomSetup.tsx
@@ -19,20 +19,20 @@ const IntercomSetup: React.FunctionComponent = () => {
 
   if (loggedIn) {
     // boot intercom in a hidden state with props
-    const userId = login.userId ? login.userId.toString() : undefined;
-    const userEmail = login.email ? login.email.toString() : undefined;
+    const userId = login.userId ? login.userId.toString() : "";
+    const userEmail = login.email ? login.email.toString() : "";
     const companyId = login.organisationId
       ? login.organisationId.toString()
       : "";
 
     const user = {
       // Data Attributes to send to intercom
-      userId: userId,
+      userId: userId + "-" + userEmail,
       userHash: login.intercomHash ? login.intercomHash : undefined,
       name: userEmail,
       email: userEmail,
       company: {
-        companyId: companyId,
+        companyId: companyId + "-" + window.DEPLOYMENT_NAME,
         name: activeOrganisation && activeOrganisation.name,
         subdomain: window.DEPLOYMENT_NAME
       },

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SempoBlockchain",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Sempo blockchain web app using Python-Flask and React",
   "main": "index.js",
   "homepage": "./",


### PR DESCRIPTION
**Describe the Pull Request**
User's with the same `userId` and `companyId` (i.e. multiple instances) will see the same chat. This risks sharing sensitive information between customers when interacting with customer support. This implements a fix by making the id's more unique with the concatenation of additional attributes.

NOTE: all existing users will lose their previous support chat history

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
