### PR TITLE
Fix partial-state transaction balance bug

### DIFF
--- a/app/server/models/transfer_account.py
+++ b/app/server/models/transfer_account.py
@@ -225,6 +225,7 @@ class TransferAccount(OneOrgBase, ModelBase, SoftDelete):
                 .filter(server.models.credit_transfer.CreditTransfer.sender_transfer_account_id == self.id)
                 .filter(or_(
                     server.models.credit_transfer.CreditTransfer.transfer_status == TransferStatusEnum.COMPLETE,
+                    server.models.credit_transfer.CreditTransfer.transfer_status == TransferStatusEnum.PARTIAL,
                     server.models.credit_transfer.CreditTransfer.transfer_status == TransferStatusEnum.PENDING))
                 .first().total
         )
@@ -243,6 +244,7 @@ class TransferAccount(OneOrgBase, ModelBase, SoftDelete):
                 .filter(server.models.credit_transfer.CreditTransfer.recipient_transfer_account_id == self.id)
                 .filter(or_(
                 server.models.credit_transfer.CreditTransfer.transfer_status == TransferStatusEnum.COMPLETE,
+                server.models.credit_transfer.CreditTransfer.transfer_status == TransferStatusEnum.PARTIAL,
                 server.models.credit_transfer.CreditTransfer.transfer_status == TransferStatusEnum.PENDING))
                 .first().total
         )

--- a/app/test_app/unit/models/test_transfer_account.py
+++ b/app/test_app/unit/models/test_transfer_account.py
@@ -1,6 +1,7 @@
 import pytest
 from flask import g
 from helpers.model_factories import CreditTransfer
+from decimal import Decimal
 
 def test_create_transfer_account(create_transfer_account):
     """
@@ -99,11 +100,11 @@ def test_balance_handles_partial_statuses(new_credit_transfer):
     assert sta.total_received_complete_only_wei == 0
     assert rta.total_received_complete_only_wei == 0
     
-    assert sta.total_sent_incl_pending_wei == 100
+    assert sta.total_sent_incl_pending_wei == 10000000000000000000
     assert rta.total_sent_incl_pending_wei == 0
 
     assert sta.total_received_incl_pending_wei == 0
-    assert rta.total_received_incl_pending_wei == 100
+    assert rta.total_received_incl_pending_wei == 10000000000000000000
 
     # Check balance correctness after updated in PARTIAL state (no change from PENDING)
     new_credit_transfer.transfer_status = 'PARTIAL'
@@ -118,11 +119,11 @@ def test_balance_handles_partial_statuses(new_credit_transfer):
     assert sta.total_received_complete_only_wei == 0
     assert rta.total_received_complete_only_wei == 0
 
-    assert sta.total_sent_incl_pending_wei == 100
+    assert sta.total_sent_incl_pending_wei == 10000000000000000000
     assert rta.total_sent_incl_pending_wei == 0
 
     assert sta.total_received_incl_pending_wei == 0
-    assert rta.total_received_incl_pending_wei == 100
+    assert rta.total_received_incl_pending_wei == 10000000000000000000
 
     # When COMPLETE, the 100 should be out of sender AND in rta
     new_credit_transfer.transfer_status = 'COMPLETE'
@@ -131,17 +132,17 @@ def test_balance_handles_partial_statuses(new_credit_transfer):
     assert sta.balance == 9000
     assert rta.balance == 11000
 
-    assert sta.total_sent_complete_only_wei == 100
+    assert sta.total_sent_complete_only_wei == 10000000000000000000
     assert rta.total_sent_complete_only_wei == 0
 
     assert sta.total_received_complete_only_wei == 0
-    assert rta.total_received_complete_only_wei == 100
+    assert rta.total_received_complete_only_wei == 10000000000000000000
     
-    assert sta.total_sent_incl_pending_wei == 100
+    assert sta.total_sent_incl_pending_wei == 10000000000000000000
     assert rta.total_sent_incl_pending_wei == 0
 
     assert sta.total_received_incl_pending_wei == 0
-    assert rta.total_received_incl_pending_wei == 100
+    assert rta.total_received_incl_pending_wei == 10000000000000000000
 
 def test_total_sent_amounts(new_credit_transfer):
     """

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.9.9'  # Remember to bump this in every PR
+VERSION = '1.9.10'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**
Transactions in the `PARTIAL` state were not being counted properly, and as such the balances were incorrect when running a bulk disbursement. This rectifies that error, and adds additional testing.

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
- [ ] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoBlockchain/blob/master/CHANGELOG.md#unreleased)
