### PR TITLE
version

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.10.4'  # Remember to bump this in every PR
+VERSION = '1.10.5'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
# Transfer Cards V2  
Presently there is no way to check transfer account limits offline. We need to add the ability to set limits which work completely when offline, and which match the logic we employ online so transactions don't fail at synchronization time. This is all based on the Mifare Ultralight EV1

## Design Considerations  
- We do not want end users to be allowed to alter their own limits  
- Limits should be mutable on the backend, and synchronized to the cards as soon as possible  
- Limits must be uniformly applied in both offline, and online flow  

## Risks  
- A limited card could need need the contents of the cards to be different. This could present compatibility challenges if we want to move old cards to the new system.  
  - A way to mitigate this would be to ignore the requirement for V1/V2 compatibility and start fresh on a new deployment. The app be altered to recognize V1 cards and run them in a compatibility mode using the old logic (without limits), but not allow migration to the new system.  
- Any solution will inevitably use more storage on the cards, so we have to make sure all of the cards we use have enough storage space   
 
## Per-Card Limits  
To implement per-card limits, we need to store two things on the card: What the limit is, and where the user currently falls within that limit. 
### High-Level Goals
- Be small. We want to use as little storage as possible. The smaller each limit is, the more limits we can actually impose
- Be secure. We don't want a user with nfctools installed to be able to override their limits when dealing with offline vendors. Our model already relies on trusting the vendor-side to sign transactions, and we should be able to apply a similar model here as well. 
- Be accountable. It should be detectable if the limits are somehow mutated on the cards, and by whom. The backend should be able to look at when/where/how a limit was exceeded once the client data becomes synchronized
- Be current. There should be version safety-- if limits change, they should be synchronized with the cards as soon as possible. Furthermore, an out-of-date offline vendor should not be able to accidentally update a card with out-of-date filter data.  

### Stored Items  
To make this work, there's a few different data types we need to consider and keep track of
- Limit types. A limit could be anything from "number of transactions allowed in a time period" or "dollar-value of allowed transactions per period"
- The limits themselves. If we established a limit type, for example here "transactions per month", we need the actual limit value (I.e. **30** transactions per month)
- Progress. The card would also have to hold where the user falls within that limit. 
- Version. To make sure the limits on the card are up-to-date, we need to store the current version of the limit-string being used. This string will only increment when the limit increases on the backend.    
- Hash. This is a 20 byte hash of the contents of the stored items, as well as the balances. 
  

### Sizes  
Note: We don't have to worry about storing the balance, since the balance is already stored
- Total storage: 48 Bytes (user accessible data fields)
- sha1 Hash: 20 Bytes (hash)
- last updated: 1 Byte (unsinged integer). This is the number of days since the start of the program (organisation creation time)
- currency amount: 3 Bytes (unsigned integer). This is based on the fact that we use the 24 bit (3 byte) counter on the NFC cards-- the maximum theoretical balance a person can have is 16777215. As such, I think we should be able to standardize on 8 bytes to represent currency in our limits code as well.
- count: 2 Bytes (unsigned integer). This will be used to represent the count in count-based limits (I.e. 'Allowed transactions per month') This can represent numbers up to 65535, which should more than facilitate any reasonable transaction limits we want to impose
- version: 1 Byte (unsigned integer). The current version of limits imposed on a card. Using only one byte since it's unlikely that we'll change an individual card's transfer limits more than 255 times
- limit type: 1 byte. This is how much storage we allocate for a given limit type. More on this later!  

### Schema 
Now that we've established what we want to do, how large each component is, and how much space we have to work with, we need to consider our data schema. How much do we want to arrange these elements on the card to convey meaning? First we should establish limit types.   

**limit types:**  
For limit types, something can either be a `count limit`, which is like "number of transactions allowed per week", or a `value limit`, which would be "how much you're allowed to spend in a week". Therefore, for this piece of information we can allocate just one bit.   
| Limit Type  | Value |
|-------------|-------|
| Count Limit | 0     |
| Value Limit | 1     |  

Next we want to think of timelines on which we might want to set these limits. Daily, Weekly, Biweekly (every two weeks), Monthly, Bimonthly (every two months), Quarterly, Yearly. This is 7 bits, so it fits nicely in an unsigned 3 bit integer. With a one bit limit-type, and 7 bits for timespan types, the entire limit type fits neatly into an into a single byte.
| Timepsan | Value |
|------------|-------|
| Daily      | 1     |
| Weekly     | 2     |
| Biweekly   | 3     |
| Monthly    | 4     |
| Bimonthly  | 5     |
| Quarterly  | 6     |
| Yearly     | 7     |

Therefore, a weekly value limit would be written as `10000010`, where the first `1` connotes that it's a value limit, followed by `0000010` (or 2), connoting `weekly`! 
```
                   Limit Type
   ┌────────────┬──────────────────────────────┐
   │    Type    │         Timespan             │
   │   (1 Bit)  │         (7 Bits)             │
   │      1     │       (2) 0000010            │
   └────────────┴──────────────────────────────┘
```
**limit type formats**
You may have noticed in sizes that `count` is half the size of `currency amount`. This is because the highest number of transactions we're ever going to want to limit is likely much smaller than the highest amount of currency, and we want to save as much space as possible. One thing this does though, is forces us to be a bit more careful with memory allocation. Since a  `Count Limit` will use less overall space than a `Value Limit`, therefore when parsing our memory we have to be a bit more clever than to just chop up the string by bits!  
For `Count Limit`, the first 8 bits are going to be the limit type itself (see above), followed by two bytes for the limit count (number of transactions allowed), and another two bytes for how much of that count has already been consumed. The exact same applies for `Value Limit` types, but the next two sections of memory will be 3 bytes long (to connote currency rather than a count). The below example is a continuation of above, but will represent "A weekly value limit of 500, 250 has already been spent this period"   
```
       Limit Object (12 to 14 Bytes)
 ┌───────────┬──────────────┬──────────────┐
 │ Limit Type│ Limit Value  │  Limit Used  │
 │  (8 Bits) │(2 or 3 Bytes)│(2 or 3 Bytes)│
 │(see above)│   (500)      │    (250)     │
 │  10000010 │0...111110100 │ 0...11111010 │
 └───────────┴──────────────┴──────────────┘
```

**hash**  
We presently already use sha1 hashes to verify the integrity of the amount loaded on the cards. For this, I propose we just add the limits data to the hash function as well! One thing to note, this should be the first 20 bytes of the card, since this could maintain compatibility with the old version of the app. 

**TODO:**  
- Deeper dive into hashing  
- Explain versioning 
- Explain "last updated"/updating strategy
- Explain flushing old "limit used" data     
- Flush out TODO section  
- Wholistic examples 
Security: 
**Section a WIP**
When an invalid hash is detected by an app, raise alarm bells! This means that either the user manipulated the card themselves, or the previous app was compromised. 
