### PR TITLE
fix: creditTransfer reducer overwrite bug

### DIFF
--- a/app/client/sagas/transferAccountSagas.ts
+++ b/app/client/sagas/transferAccountSagas.ts
@@ -59,20 +59,13 @@ function* updateStateFromTransferAccount(data: TransferAccountData) {
   }
 
   const credit_sends = normalizedData.entities.credit_sends;
-  if (credit_sends) {
-    yield put(
-      LoadCreditTransferAction.updateCreditTransferListRequest(
-        credit_sends
-      )
-    );
-  }
-
   const credit_receives = normalizedData.entities.credit_receives;
-  if (credit_receives) {
+  if (credit_sends || credit_receives) {
     yield put(
-      LoadCreditTransferAction.updateCreditTransferListRequest(
-        credit_receives
-      )
+      LoadCreditTransferAction.updateCreditTransferListRequest({
+        ...credit_sends,
+        ...credit_receives
+      })
     );
   }
 


### PR DESCRIPTION
**Describe the Pull Request**
This PR fixes a bug introduced in #726 that caused `credit_sends` to be overridden by `credit_recieves` in the transferAccountSaga when loading an individual transfer account with credit transfers (i.e. `/accounts/1/` page). Caused by this line change: https://github.com/teamsempo/SempoBlockchain/pull/726/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.py&file-filters%5B%5D=.ts&file-filters%5B%5D=.tsx#r664225919

**Todo**

- [ ] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [ ] Request review from relevant @person or team
- [ ] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [ ] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
- [ ] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoBlockchain/blob/master/CHANGELOG.md#unreleased)
