### PR TITLE
Clear cache after bulk action

### DIFF
--- a/app/server/api/disbursement_api.py
+++ b/app/server/api/disbursement_api.py
@@ -19,6 +19,7 @@ from server.utils.transfer_enums import TransferSubTypeEnum, TransferModeEnum
 from server.models.utils import paginate_query
 from server.utils.executor import status_checkable_executor_job, add_after_request_checkable_executor_job
 from server.utils.access_control import AccessControl
+from server.utils.metrics.metrics_cache import clear_metrics_cache
 
 disbursement_blueprint = Blueprint('disbursement', __name__)
 
@@ -71,11 +72,13 @@ def make_transfers(disbursement_id, auto_resolve=False):
 
         db.session.commit()
         percent_complete = ((idx + 1) / len(disbursement.transfer_accounts)) * 100
+
         yield {
             'message': 'success' if percent_complete == 100 else 'pending',
             'percent_complete': math.floor(percent_complete),
             'data': {'credit_transfers': credit_transfers_schema.dump(disbursement.credit_transfers).data}
         }
+    clear_metrics_cache()
 
 class MakeDisbursementAPI(MethodView):
     @requires_auth(allowed_roles={'ADMIN': 'admin'})

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '1.11.8'  # Remember to bump this in every PR
+VERSION = '1.11.10'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**

Metrics cache should be cleared after bulk action, since cache being written to while a disbursement is taking place can lead to double-counting

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
- [ ] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoBlockchain/blob/master/CHANGELOG.md#unreleased)
