### PR TITLE
Bump timeouts for large exports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,10 +234,10 @@ workflows:
             branches:
               only:
                 - master
-                - deploy-to-ecs
+                - reload-mercy
 
           requires:
             - build
-            - test:backend
-            - test:worker
-            - test:frontend
+            #- test:backend
+            #- test:worker
+            #- test:frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,6 @@ workflows:
 
           requires:
             - build
-            #- test:backend
-            #- test:worker
-            #- test:frontend
+            - test:backend
+            - test:worker
+            - test:frontend

--- a/app/uwsgi.ini
+++ b/app/uwsgi.ini
@@ -4,3 +4,4 @@ callable = app
 enable-threads = true
 reload-mercy = 3600
 worker-reload-mercy = 3600
+http-timeout = 3600

--- a/app/uwsgi.ini
+++ b/app/uwsgi.ini
@@ -5,3 +5,4 @@ enable-threads = true
 reload-mercy = 3600
 worker-reload-mercy = 3600
 http-timeout = 3600
+lazy-apps = true

--- a/app/uwsgi.ini
+++ b/app/uwsgi.ini
@@ -2,3 +2,5 @@
 module = server.wsgi
 callable = app
 enable-threads = true
+reload-mercy = 3600
+worker-reload-mercy = 3600

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ env_loglevel = os.environ.get('LOGLEVEL', 'DEBUG')
 logging.basicConfig(level=env_loglevel)
 logg = logging.getLogger(__name__)
 
-VERSION = '2.0.0'  # Remember to bump this in every PR
+VERSION = '2.0.1'  # Remember to bump this in every PR
 
 logg.info('Loading configs at UTC {}'.format(datetime.datetime.utcnow()))
 


### PR DESCRIPTION
**Describe the Pull Request**

Make sure app workers don't get pruned while generating exports  

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
- [x] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoBlockchain/blob/master/CHANGELOG.md#unreleased)
