### PR TITLE
Make history drawer work with incomplete data

### DIFF
--- a/app/client/components/history/historyDrawer.tsx
+++ b/app/client/components/history/historyDrawer.tsx
@@ -23,9 +23,7 @@ class HistoryDrawer extends React.Component<Props> {
       const column_name = toTitleCase(replaceUnderscores(change.column_name));
       const created = change.created;
       return {
-        item: `${toTitleCase(
-          replaceUnderscores(column_name)
-        )} changed from "${old_value}" to "${new_value}"`,
+        item: `${column_name} changed from "${old_value}" to "${new_value}"`,
         date: created,
         email: email,
       };

--- a/app/client/components/history/historyDrawer.tsx
+++ b/app/client/components/history/historyDrawer.tsx
@@ -16,13 +16,18 @@ class HistoryDrawer extends React.Component<Props> {
   }
 
   render() {
-    const stringList = this.props.changes.map(change => {
+    const stringList = this.props.changes.map((change) => {
+      const email = change.change_by ? change.change_by.email : "Unknown";
+      const old_value = change.old_value ? change.old_value : "null";
+      const new_value = change.new_value ? change.new_value : "null";
+      const column_name = toTitleCase(replaceUnderscores(change.column_name));
+      const created = change.created;
       return {
         item: `${toTitleCase(
-          replaceUnderscores(change.column_name)
-        )} changed from "${change.old_value}" to "${change.new_value}"`,
-        date: change.created,
-        email: change.change_by.email
+          replaceUnderscores(column_name)
+        )} changed from "${old_value}" to "${new_value}"`,
+        date: created,
+        email: email,
       };
     });
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SempoBlockchain",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Sempo blockchain web app using Python-Flask and React",
   "main": "index.js",
   "homepage": "./",


### PR DESCRIPTION
**Describe the Pull Request**

If there was a null from the history API, the history drawer would crash. This makes it a bit more robust!   

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
- [ ] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoBlockchain/blob/master/CHANGELOG.md#unreleased)
