### PR TITLE
Let user go directly to map

### DIFF
--- a/app/client/components/pages/mapPage.jsx
+++ b/app/client/components/pages/mapPage.jsx
@@ -8,9 +8,9 @@ import NoDataMessage from "../NoDataMessage";
 
 const HeatMap = lazy(() => import("../heatmap/heatmap.jsx"));
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
-    metricsLoadStatus: state.metrics.loadStatus
+    metricsLoadStatus: state.metrics.loadStatus,
   };
 };
 
@@ -23,7 +23,9 @@ class MapPage extends React.Component {
     return (
       <WrapperDiv>
         <PageWrapper>
-          {this.props.metricsLoadStatus.success ? (
+          {this.props.metricsLoadStatus.success ||
+          (!this.props.metricsLoadStatus.success &&
+            !this.props.metricsLoadStatus.isRequesting) ? (
             <div>
               <Card
                 style={{
@@ -31,7 +33,7 @@ class MapPage extends React.Component {
                   top: 0,
                   zIndex: 1,
                   margin: "1em",
-                  maxWidth: "calc(100vw - 2em)"
+                  maxWidth: "calc(100vw - 2em)",
                 }}
               >
                 <FilterModule


### PR DESCRIPTION
**Describe the Pull Request**

If you go to the `/map` page without first loading metrics someplace else, the FE will get confused and not load the map. This fixes!  

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoBlockchain/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, checking [accessibility](https://www.a11yproject.com/checklist/) etc.
- [x] Bump [backend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/config.py#L7) and/or [frontend](https://github.com/teamsempo/SempoBlockchain/blob/e3eb0f480e86d5a8ef2c1814127b70ff018671c4/app/package.json#L3) versions following Semver
- [ ] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoBlockchain/blob/master/CHANGELOG.md#unreleased)
